### PR TITLE
fix: seed watch DB on first launch

### DIFF
--- a/mobile/src/main/java/com/meatsack/motivator/mobile/MeatsackMobileApp.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/MeatsackMobileApp.kt
@@ -2,7 +2,7 @@ package com.meatsack.motivator.mobile
 
 import android.app.Application
 import android.util.Log
-import com.meatsack.motivator.mobile.data.SeedData
+import com.meatsack.shared.data.SeedData
 import com.meatsack.shared.db.AppDatabase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/shared/src/main/java/com/meatsack/shared/data/SeedData.kt
+++ b/shared/src/main/java/com/meatsack/shared/data/SeedData.kt
@@ -1,4 +1,4 @@
-package com.meatsack.motivator.mobile.data
+package com.meatsack.shared.data
 
 import com.meatsack.shared.constants.EscalationLevel
 import com.meatsack.shared.constants.MessageSource

--- a/wear/src/main/java/com/meatsack/motivator/MeatsackWearApp.kt
+++ b/wear/src/main/java/com/meatsack/motivator/MeatsackWearApp.kt
@@ -1,9 +1,13 @@
 package com.meatsack.motivator
 
 import android.app.Application
+import android.util.Log
+import com.meatsack.shared.data.SeedData
+import com.meatsack.shared.db.AppDatabase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 class MeatsackWearApp : Application() {
     /**
@@ -12,4 +16,33 @@ class MeatsackWearApp : Application() {
      * SupervisorJob so one failing child doesn't cancel siblings.
      */
     val applicationScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate() {
+        super.onCreate()
+        seedDatabaseIfEmpty()
+    }
+
+    /**
+     * Mirrors MeatsackMobileApp's seeder so the watch has a usable message pool
+     * out of the box, without requiring the user to tap "Sync to Watch" first.
+     * Sync becomes useful for delta updates (AI-generated additions, curation)
+     * rather than a prerequisite for any insults firing.
+     */
+    private fun seedDatabaseIfEmpty() {
+        applicationScope.launch {
+            try {
+                val db = AppDatabase.getDatabase(this@MeatsackWearApp)
+                if (db.messageDao().getMessageCount() == 0) {
+                    db.messageDao().insertAll(SeedData.getPreWrittenMessages())
+                    Log.d(TAG, "Seeded watch database with pre-written messages")
+                }
+            } catch (t: Throwable) {
+                Log.e(TAG, "Failed to seed watch database; insults will not fire", t)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "MeatsackWearApp"
+    }
 }


### PR DESCRIPTION
## Problem

On real hardware, the watch app fires zero insults. I tracked it on a Galaxy Watch 8 that had the service running for 2+ days with step tracking working and logging normally — nothing ever fired. Pulled the watch DB and found:

```
SELECT COUNT(*) FROM messages;  -- 0
```

The v1 architecture seeds the message library only on the **phone** (`MeatsackMobileApp.seedDatabaseIfEmpty`). The watch gets messages via the **Sync to Watch** button in the phone app's Library tab. If the user never taps it (or it fails silently), the watch has nothing to fire — `MessageRepository.selectMessage()` returns null, `checkInactivity()` bails silently, no user-visible signal that anything is wrong.

## Fix

Move `SeedData` from `:mobile` to `:shared` so both modules reference the same source-of-truth list. Mirror `seedDatabaseIfEmpty()` into `MeatsackWearApp.onCreate` using the app's existing `applicationScope` (SupervisorJob + IO). On first launch after install, the watch self-seeds.

**Sync to Watch remains useful** for delta updates (AI-generated additions, library curation in v2+) but is no longer a prerequisite for the app to work.

## Changes

| File | Change |
|---|---|
| `shared/.../data/SeedData.kt` | Moved from `:mobile` (git rename, content unchanged except package line) |
| `mobile/.../MeatsackMobileApp.kt` | Import updated to `com.meatsack.shared.data.SeedData` |
| `wear/.../MeatsackWearApp.kt` | Added `onCreate` override calling new `seedDatabaseIfEmpty()` |

## Test plan

- [x] Unit tests pass across all modules
- [x] `./gradlew spotlessCheck` clean
- [x] Both APKs assembleDebug cleanly
- [ ] After reinstall on a real Galaxy Watch, confirm `SELECT COUNT(*) FROM messages` > 0 without tapping Sync to Watch
- [ ] After reinstall, wait 30+ minutes sitting still — verify an insult actually fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)