### PR TITLE
fix(sync): bump PhoneSyncSender cache size 50 -> 200

### DIFF
--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSyncSender.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSyncSender.kt
@@ -24,7 +24,19 @@ class PhoneSyncSender(private val context: Context) {
 
     companion object {
         private const val TAG = "PhoneSyncSender"
-        private const val CACHE_SIZE = 50
+
+        /**
+         * Maximum messages pushed in a single DataItem. Sized to comfortably hold
+         * the full v2 seed (69 rows: INACTIVITY + BEHIND_PACE + END_OF_DAY) plus
+         * headroom for AI-generated growth, while staying well under Wear's
+         * ~100 KB DataItem limit (200 × ~200 chars × 2 bytes ≈ 80 KB).
+         *
+         * Was 50 in v1 when the seed had only 49 INACTIVITY rows; that ceiling
+         * silently truncated v2 seed rows on phones with no voted messages,
+         * meaning watch-side workers couldn't find BEHIND_PACE/END_OF_DAY
+         * messages and always fell back to the INACTIVITY pool.
+         */
+        private const val CACHE_SIZE = 200
     }
 
     suspend fun syncMessagesToWatch(): SyncResult {


### PR DESCRIPTION
## Summary

PhoneSyncSender's CACHE_SIZE was 50 — perfectly sized for v1 (49 INACTIVITY rows) but too tight for v2 (49 + 20 = 69 seed rows + AI-generated growth).

When all rows are tied at 0 votes (cold-start before any voting), SQLite tiebreaker is ROWID order. v2's BEHIND_PACE + END_OF_DAY rows were appended last in `SeedData.getPreWrittenMessages()`, so they have the highest ROWIDs, so they're exactly the rows that `.take(50)` drops.

**Effect:** watch-side DB never received BEHIND_PACE / END_OF_DAY messages, and the corresponding workers always fell back to the INACTIVITY pool. Confirmed on real Galaxy Watch hardware via:

```
W BehindPaceWorker: No BEHIND_PACE message for level=EXISTENTIAL tone=FULL_SEND
                    — falling back to inactivity pool
```

## Fix

CACHE_SIZE: 50 → 200. Sized to comfortably fit v2 seed + AI growth while staying well under Wear's ~100 KB DataItem limit (200 × ~200 chars × 2 bytes ≈ 80 KB).

## Test plan

- [x] `:mobile:assembleDebug` clean
- [x] `:mobile:testDebugUnitTest` clean
- [ ] Hardware: tap Sync to Watch on phone → confirm watch DB now receives BEHIND_PACE rows → next BehindPaceWorker tick finds a BEHIND_PACE message at the right level (no INACTIVITY fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)