### PR TITLE
Phone→watch settings sync via /settings DataItem (closes #23)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-phone-watch-settings-sync.md
+++ b/docs/superpowers/plans/2026-05-30-phone-watch-settings-sync.md
@@ -1,0 +1,1570 @@
+# Phone → Watch Settings Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire phone settings through to the watch by introducing a `/settings` DataItem channel backed by a single shared `SettingsSnapshot`, closing schema-drift bugs along the way (closes #23, partially addresses #25).
+
+**Architecture:** New `:shared/sync/` types — `SettingsKeys`, `SettingsSnapshot`, hoisted `SettingsDefaults` — give phone (writer) and watch (reader) a compile-time-checked contract. `PhoneSettingsSyncer` on the phone observes `SettingsRepository` flows (`debounce(500ms)` + `distinctUntilChanged()`) and writes a `PutDataMapRequest`; `MainActivity.onResume` also triggers a one-shot snapshot via `syncNow()`. `WatchSettingsReceiver` (a `WearableListenerService`) reads the DataItem and writes into `WatchSettingsCache`. As a side effect we add `behindPaceCheckHour` to phone UI and rewire `EscalationManager` to read its inactivity threshold from `WatchSettingsCache` instead of a hardcoded constant.
+
+**Tech Stack:** Kotlin, Jetpack Compose (mobile UI), Jetpack DataStore (phone), SharedPreferences (watch), Wear Data Layer (`com.google.android.gms.wearable`), JUnit + Turbine + `kotlinx-coroutines-test`. Robolectric only if `DataMap` turns out not to be pure-JVM-instantiable (verify in Task 3).
+
+**Spec:** `docs/superpowers/specs/2026-05-30-phone-watch-settings-sync-design.md`
+
+---
+
+## File Structure
+
+### New
+
+| Path | Responsibility |
+|---|---|
+| `shared/src/main/java/com/meatsack/shared/sync/SettingsDefaults.kt` | Default values for the 7 watch-relevant settings, shared by phone + watch. |
+| `shared/src/main/java/com/meatsack/shared/sync/SettingsKeys.kt` | DataMap path + key constants for the `/settings` channel. |
+| `shared/src/main/java/com/meatsack/shared/sync/SettingsSnapshot.kt` | Immutable 7-field data class with `toDataMap`/`fromDataMap`. |
+| `shared/src/test/java/com/meatsack/shared/sync/SettingsSnapshotTest.kt` | Round-trip, defaults-on-missing, hour coercion, defaults parity. |
+| `mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt` | Observes `SettingsRepository` flows, debounces, writes `/settings` DataItem. Exposes `syncNow()`. |
+| `mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt` | `syncNow` correctness; debounce + distinctUntilChanged; bounded retry. |
+| `wear/src/main/java/com/meatsack/motivator/sync/WatchSettingsReceiver.kt` | `WearableListenerService` that applies `/settings` DataItem to `WatchSettingsCache`. |
+| `wear/src/test/java/com/meatsack/motivator/sync/WatchSettingsReceiverTest.kt` | Pure-JVM test of `applySnapshot` against a fake sink. |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsDefaults.kt` | Trim to `QUIET_HOURS_START`/`QUIET_HOURS_END` only. |
+| `mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt` | Add `behindPaceCheckHour: Flow<Int>` + `setBehindPaceCheckHour`. Update imports to source 6 defaults from `:shared`. |
+| `mobile/src/test/java/com/meatsack/motivator/mobile/data/SettingsRepositoryTest.kt` | Add `validateHour` tests for the new setter. |
+| `mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt` | Expose `behindPaceCheckHour` StateFlow + `updateBehindPaceCheckHour`. |
+| `mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsScreen.kt` | Add 0..23 slider for `behindPaceCheckHour`. |
+| `mobile/src/main/java/com/meatsack/motivator/mobile/MeatsackMobileApp.kt` | Construct `PhoneSettingsSyncer`; expose; call `.start(applicationScope)` in `onCreate`. |
+| `mobile/src/main/java/com/meatsack/motivator/mobile/MainActivity.kt` | `onResume` launches `syncer.syncNow()`. |
+| `wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt` | Add `inactivityThreshold` field. Replace hardcoded literal defaults with `:shared` `SettingsDefaults`. |
+| `wear/src/main/java/com/meatsack/motivator/escalation/EscalationManager.kt` | Constructor takes `thresholdProvider: () -> Int`; replace 2 reads of `EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT` with `thresholdProvider()`. |
+| `wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt` | Pass `{ watchSettingsCache.inactivityThreshold }` to `EscalationManager`. |
+| `wear/src/main/AndroidManifest.xml` | Register `WatchSettingsReceiver` with `<data-item-filter>` for `SettingsKeys.PATH`. |
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0: Confirm branch**
+
+Run: `git status`
+Expected: `On branch feature/phone-watch-settings-sync`. If not, run `git checkout feature/phone-watch-settings-sync`. The spec was already committed on this branch as `35a3dc5`.
+
+---
+
+## Task 1: Hoist `SettingsDefaults` to `:shared` and trim phone-side
+
+**Files:**
+- Create: `shared/src/main/java/com/meatsack/shared/sync/SettingsDefaults.kt`
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsDefaults.kt`
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt`
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt`
+- Modify: `wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt`
+
+- [ ] **Step 1.1: Create shared defaults**
+
+`shared/src/main/java/com/meatsack/shared/sync/SettingsDefaults.kt`:
+
+```kotlin
+package com.meatsack.shared.sync
+
+/**
+ * Default values for the 7 settings the watch consumes. Mirrored by phone
+ * (SettingsRepository fallbacks) and watch (WatchSettingsCache fallbacks).
+ * Single source of truth — adding a default here is the only place to change it.
+ */
+object SettingsDefaults {
+    const val DAILY_STEP_GOAL = 10_000
+    const val INACTIVITY_THRESHOLD_MIN = 30
+    const val ACTIVE_HOURS_START = 7
+    const val ACTIVE_HOURS_END = 22
+    const val CONTEXT_AWARE_ENABLED = false
+    const val END_OF_DAY_HOUR = 21 // 9pm
+    const val BEHIND_PACE_CHECK_HOUR = 12 // noon
+}
+```
+
+- [ ] **Step 1.2: Trim phone-side `SettingsDefaults`**
+
+Overwrite `mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsDefaults.kt`:
+
+```kotlin
+package com.meatsack.motivator.mobile.data
+
+/**
+ * Phone-only setting defaults. The 7 watch-shared defaults moved to
+ * com.meatsack.shared.sync.SettingsDefaults in the settings-sync work.
+ */
+object SettingsDefaults {
+    const val QUIET_HOURS_START = 22
+    const val QUIET_HOURS_END = 7
+}
+```
+
+- [ ] **Step 1.3: Update `SettingsRepository` to read shared defaults**
+
+In `mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt`, add this import at the top (alongside existing imports):
+
+```kotlin
+import com.meatsack.shared.sync.SettingsDefaults as SharedDefaults
+```
+
+Then replace every `SettingsDefaults.<CONST>` reference for the 6 hoisted constants with `SharedDefaults.<CONST>`. Leave `SettingsDefaults.QUIET_HOURS_START` and `SettingsDefaults.QUIET_HOURS_END` unchanged. Concretely, lines using `SettingsDefaults.DAILY_STEP_GOAL`, `SettingsDefaults.INACTIVITY_THRESHOLD_MIN`, `SettingsDefaults.ACTIVE_HOURS_START`, `SettingsDefaults.ACTIVE_HOURS_END`, `SettingsDefaults.CONTEXT_AWARE_ENABLED`, `SettingsDefaults.END_OF_DAY_HOUR` should be updated.
+
+(Note: `SettingsRepository` doesn't currently import `SettingsDefaults` explicitly — it resolves via the same package. Adding the `import as SharedDefaults` is the cleanest way to differentiate.)
+
+- [ ] **Step 1.4: Update `SettingsViewModel` the same way**
+
+In `mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt`, add at top:
+
+```kotlin
+import com.meatsack.shared.sync.SettingsDefaults as SharedDefaults
+```
+
+Replace the 6 hoisted-constant uses (`SettingsDefaults.DAILY_STEP_GOAL`, `SettingsDefaults.INACTIVITY_THRESHOLD_MIN`, `SettingsDefaults.ACTIVE_HOURS_START`, `SettingsDefaults.ACTIVE_HOURS_END`, `SettingsDefaults.CONTEXT_AWARE_ENABLED`, `SettingsDefaults.END_OF_DAY_HOUR`) with `SharedDefaults.<CONST>`. Leave `SettingsDefaults.QUIET_HOURS_START` / `_END` unchanged.
+
+- [ ] **Step 1.5: Update `WatchSettingsCache` to read shared defaults**
+
+In `wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt`, add import:
+
+```kotlin
+import com.meatsack.shared.sync.SettingsDefaults
+```
+
+Then replace each literal default value in the property getters with the matching `SettingsDefaults` constant. The current file is:
+
+```kotlin
+var contextAwareEnabled: Boolean
+    get() = prefs.getBoolean(KEY_CONTEXT_AWARE, false)
+    ...
+var activeHoursStart: Int
+    get() = prefs.getInt(KEY_ACTIVE_START, 7)
+    ...
+var activeHoursEnd: Int
+    get() = prefs.getInt(KEY_ACTIVE_END, 22)
+    ...
+var dailyStepGoal: Int
+    get() = prefs.getInt(KEY_GOAL, 10_000)
+    ...
+var endOfDayHour: Int
+    get() = prefs.getInt(KEY_END_OF_DAY, 21)
+    ...
+var behindPaceCheckHour: Int
+    get() = prefs.getInt(KEY_BEHIND_PACE_HOUR, 12)
+    ...
+```
+
+It should become:
+
+```kotlin
+var contextAwareEnabled: Boolean
+    get() = prefs.getBoolean(KEY_CONTEXT_AWARE, SettingsDefaults.CONTEXT_AWARE_ENABLED)
+    ...
+var activeHoursStart: Int
+    get() = prefs.getInt(KEY_ACTIVE_START, SettingsDefaults.ACTIVE_HOURS_START)
+    ...
+var activeHoursEnd: Int
+    get() = prefs.getInt(KEY_ACTIVE_END, SettingsDefaults.ACTIVE_HOURS_END)
+    ...
+var dailyStepGoal: Int
+    get() = prefs.getInt(KEY_GOAL, SettingsDefaults.DAILY_STEP_GOAL)
+    ...
+var endOfDayHour: Int
+    get() = prefs.getInt(KEY_END_OF_DAY, SettingsDefaults.END_OF_DAY_HOUR)
+    ...
+var behindPaceCheckHour: Int
+    get() = prefs.getInt(KEY_BEHIND_PACE_HOUR, SettingsDefaults.BEHIND_PACE_CHECK_HOUR)
+    ...
+```
+
+(Leave `set(value)` lines unchanged.)
+
+- [ ] **Step 1.6: Build all modules to verify**
+
+Run: `./gradlew :shared:compileDebugKotlin :mobile:compileDebugKotlin :wear:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 1.7: Run existing unit tests**
+
+Run: `./gradlew :shared:testDebugUnitTest :mobile:testDebugUnitTest :wear:testDebugUnitTest`
+Expected: All pass. (No new tests yet — verifying we didn't break anything during the hoist.)
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add shared/src/main/java/com/meatsack/shared/sync/SettingsDefaults.kt \
+        mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsDefaults.kt \
+        mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt \
+        mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt \
+        wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
+git commit -m "refactor: hoist 6 watch-shared defaults to :shared/sync/SettingsDefaults (#23)"
+```
+
+---
+
+## Task 2: Add `SettingsKeys`
+
+**Files:**
+- Create: `shared/src/main/java/com/meatsack/shared/sync/SettingsKeys.kt`
+
+- [ ] **Step 2.1: Create the file**
+
+```kotlin
+package com.meatsack.shared.sync
+
+/**
+ * Wire-level keys for the /settings DataItem channel. Single source of truth for
+ * both PhoneSettingsSyncer (writer) and WatchSettingsReceiver (reader). Adding
+ * a key here is the only edit needed before wiring it on each side.
+ *
+ * No KEY_TIMESTAMP: DataClient dedupes by content bytes, and settings have no
+ * "stale" semantics on the watch — including a timestamp would fire onDataChanged
+ * on every send even when nothing changed. Deliberate divergence from /messages.
+ */
+object SettingsKeys {
+    const val PATH = "/settings"
+    const val KEY_DAILY_STEP_GOAL = "daily_step_goal"
+    const val KEY_INACTIVITY_THRESHOLD = "inactivity_threshold_min"
+    const val KEY_ACTIVE_HOURS_START = "active_hours_start"
+    const val KEY_ACTIVE_HOURS_END = "active_hours_end"
+    const val KEY_CONTEXT_AWARE_ENABLED = "context_aware_enabled"
+    const val KEY_END_OF_DAY_HOUR = "end_of_day_hour"
+    const val KEY_BEHIND_PACE_CHECK_HOUR = "behind_pace_check_hour"
+}
+```
+
+- [ ] **Step 2.2: Build :shared**
+
+Run: `./gradlew :shared:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add shared/src/main/java/com/meatsack/shared/sync/SettingsKeys.kt
+git commit -m "feat: add SettingsKeys for /settings DataItem channel (#23)"
+```
+
+---
+
+## Task 3: `SettingsSnapshot` tests (red)
+
+This is TDD step 1 — write tests that fail because the class doesn't exist yet.
+
+**Files:**
+- Create: `shared/src/test/java/com/meatsack/shared/sync/SettingsSnapshotTest.kt`
+
+- [ ] **Step 3.1: Write the failing test**
+
+```kotlin
+package com.meatsack.shared.sync
+
+import com.google.android.gms.wearable.DataMap
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SettingsSnapshotTest {
+
+    @Test
+    fun defaults_matchSettingsDefaults() {
+        val snap = SettingsSnapshot.defaults
+        assertEquals(SettingsDefaults.DAILY_STEP_GOAL, snap.dailyStepGoal)
+        assertEquals(SettingsDefaults.INACTIVITY_THRESHOLD_MIN, snap.inactivityThreshold)
+        assertEquals(SettingsDefaults.ACTIVE_HOURS_START, snap.activeHoursStart)
+        assertEquals(SettingsDefaults.ACTIVE_HOURS_END, snap.activeHoursEnd)
+        assertEquals(SettingsDefaults.CONTEXT_AWARE_ENABLED, snap.contextAwareEnabled)
+        assertEquals(SettingsDefaults.END_OF_DAY_HOUR, snap.endOfDayHour)
+        assertEquals(SettingsDefaults.BEHIND_PACE_CHECK_HOUR, snap.behindPaceCheckHour)
+    }
+
+    @Test
+    fun toDataMap_fromDataMap_roundTrip() {
+        val original = SettingsSnapshot(
+            dailyStepGoal = 12_345,
+            inactivityThreshold = 45,
+            activeHoursStart = 8,
+            activeHoursEnd = 21,
+            contextAwareEnabled = true,
+            endOfDayHour = 20,
+            behindPaceCheckHour = 14,
+        )
+        val dm = DataMap()
+        original.toDataMap(dm)
+        val parsed = SettingsSnapshot.fromDataMap(dm)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun fromDataMap_missingKeys_returnsDefaults() {
+        val dm = DataMap() // empty
+        val parsed = SettingsSnapshot.fromDataMap(dm)
+        assertEquals(SettingsSnapshot.defaults, parsed)
+    }
+
+    @Test
+    fun fromDataMap_outOfRangeHours_clampedTo0to23() {
+        val dm = DataMap()
+        dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_START, -5)
+        dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_END, 99)
+        dm.putInt(SettingsKeys.KEY_END_OF_DAY_HOUR, 24)
+        dm.putInt(SettingsKeys.KEY_BEHIND_PACE_CHECK_HOUR, -1)
+        // Non-hour fields put through so we read defaults for them:
+        val parsed = SettingsSnapshot.fromDataMap(dm)
+        assertEquals(0, parsed.activeHoursStart)
+        assertEquals(23, parsed.activeHoursEnd)
+        assertEquals(23, parsed.endOfDayHour)
+        assertEquals(0, parsed.behindPaceCheckHour)
+    }
+}
+```
+
+- [ ] **Step 3.2: Run the test, expecting compile failure**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "com.meatsack.shared.sync.SettingsSnapshotTest"`
+
+Expected: COMPILE FAILURE — `Unresolved reference: SettingsSnapshot`. If you instead get a DataMap-related error like `java.lang.NoClassDefFoundError` or a Robolectric-required hint, note this — Task 4 step 4.3 has a contingency.
+
+- [ ] **Step 3.3: Do not commit yet**
+
+The build is currently red. Move to Task 4.
+
+---
+
+## Task 4: Implement `SettingsSnapshot` (green)
+
+**Files:**
+- Create: `shared/src/main/java/com/meatsack/shared/sync/SettingsSnapshot.kt`
+- Possibly modify: `shared/build.gradle.kts` (Robolectric dep if DataMap test fails on JVM)
+
+- [ ] **Step 4.1: Create the data class**
+
+```kotlin
+package com.meatsack.shared.sync
+
+import com.google.android.gms.wearable.DataMap
+
+/**
+ * Wire-shape for the /settings DataItem channel. Single source of truth for the
+ * field set — adding a property here forces both phone (writer) and watch
+ * (reader) to handle the new field, which is the structural fix for issue #23.
+ *
+ * fromDataMap returns SettingsDefaults values for any missing keys (forward
+ * and backward compatibility) and coerces hour fields to 0..23 (defense in
+ * depth against malformed payloads; phone's validateHour should already
+ * prevent invalid sends).
+ */
+data class SettingsSnapshot(
+    val dailyStepGoal: Int,
+    val inactivityThreshold: Int,
+    val activeHoursStart: Int,
+    val activeHoursEnd: Int,
+    val contextAwareEnabled: Boolean,
+    val endOfDayHour: Int,
+    val behindPaceCheckHour: Int,
+) {
+
+    fun toDataMap(dm: DataMap) {
+        dm.putInt(SettingsKeys.KEY_DAILY_STEP_GOAL, dailyStepGoal)
+        dm.putInt(SettingsKeys.KEY_INACTIVITY_THRESHOLD, inactivityThreshold)
+        dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_START, activeHoursStart)
+        dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_END, activeHoursEnd)
+        dm.putBoolean(SettingsKeys.KEY_CONTEXT_AWARE_ENABLED, contextAwareEnabled)
+        dm.putInt(SettingsKeys.KEY_END_OF_DAY_HOUR, endOfDayHour)
+        dm.putInt(SettingsKeys.KEY_BEHIND_PACE_CHECK_HOUR, behindPaceCheckHour)
+    }
+
+    companion object {
+        val defaults = SettingsSnapshot(
+            dailyStepGoal = SettingsDefaults.DAILY_STEP_GOAL,
+            inactivityThreshold = SettingsDefaults.INACTIVITY_THRESHOLD_MIN,
+            activeHoursStart = SettingsDefaults.ACTIVE_HOURS_START,
+            activeHoursEnd = SettingsDefaults.ACTIVE_HOURS_END,
+            contextAwareEnabled = SettingsDefaults.CONTEXT_AWARE_ENABLED,
+            endOfDayHour = SettingsDefaults.END_OF_DAY_HOUR,
+            behindPaceCheckHour = SettingsDefaults.BEHIND_PACE_CHECK_HOUR,
+        )
+
+        fun fromDataMap(dm: DataMap): SettingsSnapshot = SettingsSnapshot(
+            dailyStepGoal = dm.getInt(SettingsKeys.KEY_DAILY_STEP_GOAL, defaults.dailyStepGoal),
+            inactivityThreshold = dm.getInt(SettingsKeys.KEY_INACTIVITY_THRESHOLD, defaults.inactivityThreshold),
+            activeHoursStart = dm.getInt(SettingsKeys.KEY_ACTIVE_HOURS_START, defaults.activeHoursStart).coerceIn(0, 23),
+            activeHoursEnd = dm.getInt(SettingsKeys.KEY_ACTIVE_HOURS_END, defaults.activeHoursEnd).coerceIn(0, 23),
+            contextAwareEnabled = dm.getBoolean(SettingsKeys.KEY_CONTEXT_AWARE_ENABLED, defaults.contextAwareEnabled),
+            endOfDayHour = dm.getInt(SettingsKeys.KEY_END_OF_DAY_HOUR, defaults.endOfDayHour).coerceIn(0, 23),
+            behindPaceCheckHour = dm.getInt(SettingsKeys.KEY_BEHIND_PACE_CHECK_HOUR, defaults.behindPaceCheckHour).coerceIn(0, 23),
+        )
+    }
+}
+```
+
+- [ ] **Step 4.2: Run the test, expecting green**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "com.meatsack.shared.sync.SettingsSnapshotTest"`
+
+Expected: All 4 tests pass. If you get a `DataMap`-related runtime error (e.g. `NoClassDefFoundError`), proceed to Step 4.3 (contingency). Otherwise skip to Step 4.4.
+
+- [ ] **Step 4.3: (Contingency) Add Robolectric to `:shared` tests**
+
+Only do this step if Step 4.2 failed with a `DataMap`-related error.
+
+Open `shared/build.gradle.kts` and confirm whether Robolectric is already configured. If not, add to dependencies:
+
+```kotlin
+testImplementation("org.robolectric:robolectric:4.11.1")
+```
+
+And in the `android { }` block, add (if missing):
+
+```kotlin
+testOptions {
+    unitTests.isIncludeAndroidResources = true
+}
+```
+
+Annotate `SettingsSnapshotTest` with `@RunWith(RobolectricTestRunner::class)` (imports: `org.junit.runner.RunWith`, `org.robolectric.RobolectricTestRunner`). Then re-run Step 4.2.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add shared/src/main/java/com/meatsack/shared/sync/SettingsSnapshot.kt \
+        shared/src/test/java/com/meatsack/shared/sync/SettingsSnapshotTest.kt
+# include build.gradle.kts only if Step 4.3 was needed:
+# git add shared/build.gradle.kts
+git commit -m "feat: SettingsSnapshot with DataMap round-trip + coerceIn(0,23) (#23)"
+```
+
+---
+
+## Task 5: Add `behindPaceCheckHour` to `SettingsRepository`
+
+**Files:**
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt`
+- Modify: `mobile/src/test/java/com/meatsack/motivator/mobile/data/SettingsRepositoryTest.kt`
+
+- [ ] **Step 5.1: Write the failing test**
+
+Append to `mobile/src/test/java/com/meatsack/motivator/mobile/data/SettingsRepositoryTest.kt`:
+
+```kotlin
+@Test
+fun validateHour_rejectsTooLarge_forBehindPaceCheck() {
+    val e = assertThrows(IllegalArgumentException::class.java) {
+        SettingsRepository.validateHour("Behind pace check hour", 24)
+    }
+    assertTrue(
+        "Message should include field name; was: ${e.message}",
+        e.message?.contains("Behind pace check hour") == true,
+    )
+}
+```
+
+(This isn't strictly *new* behavior, but it documents the intent for the new setter. The setter itself is harder to unit-test without DataStore plumbing — production-level coverage of setter happy paths comes via the manual end-to-end check.)
+
+- [ ] **Step 5.2: Run the test, expecting green (or compile-only)**
+
+Run: `./gradlew :mobile:testDebugUnitTest --tests "com.meatsack.motivator.mobile.data.SettingsRepositoryTest.validateHour_rejectsTooLarge_forBehindPaceCheck"`
+
+Expected: PASS (the existing `validateHour` already rejects 24; this is a contract test for the new field's reuse of it).
+
+- [ ] **Step 5.3: Add the field + setter to `SettingsRepository`**
+
+In `mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt`:
+
+In the `companion object`, alongside existing key definitions, add:
+
+```kotlin
+val BEHIND_PACE_CHECK_HOUR = intPreferencesKey("behind_pace_check_hour")
+```
+
+In the body, after the `endOfDayHour` Flow, add:
+
+```kotlin
+val behindPaceCheckHour: Flow<Int> = context.dataStore.data.map {
+    it[BEHIND_PACE_CHECK_HOUR] ?: SharedDefaults.BEHIND_PACE_CHECK_HOUR
+}
+```
+
+After the `setEndOfDayHour` setter, add:
+
+```kotlin
+suspend fun setBehindPaceCheckHour(hour: Int) {
+    validateHour("Behind pace check hour", hour)
+    context.dataStore.edit { it[BEHIND_PACE_CHECK_HOUR] = hour }
+}
+```
+
+- [ ] **Step 5.4: Build and run tests**
+
+Run: `./gradlew :mobile:testDebugUnitTest`
+Expected: All tests pass (including the new one).
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt \
+        mobile/src/test/java/com/meatsack/motivator/mobile/data/SettingsRepositoryTest.kt
+git commit -m "feat: add behindPaceCheckHour to SettingsRepository (#23)"
+```
+
+---
+
+## Task 6: Expose `behindPaceCheckHour` in ViewModel + slider in `SettingsScreen`
+
+No unit test for this task — Compose UI testing is heavyweight, coverage comes via the manual E2E checklist.
+
+**Files:**
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt`
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsScreen.kt`
+
+- [ ] **Step 6.1: Expose in ViewModel**
+
+In `SettingsViewModel.kt`, after the `endOfDayHour` StateFlow declaration, add:
+
+```kotlin
+val behindPaceCheckHour = repo.behindPaceCheckHour.stateIn(
+    viewModelScope,
+    SharingStarted.WhileSubscribed(),
+    SharedDefaults.BEHIND_PACE_CHECK_HOUR,
+)
+```
+
+After the `updateEndOfDayHour` function, add:
+
+```kotlin
+fun updateBehindPaceCheckHour(hour: Int) =
+    viewModelScope.launch { repo.setBehindPaceCheckHour(hour) }
+```
+
+- [ ] **Step 6.2: Add slider in `SettingsScreen`**
+
+In `SettingsScreen.kt`, in the `Composable` body, after the quiet-hours block (the second slider pair, lines around 117) and before the API-key section, add:
+
+```kotlin
+val behindPaceHour by viewModel.behindPaceCheckHour.collectAsState()
+Text(
+    "Behind-pace check hour: $behindPaceHour:00",
+    style = MaterialTheme.typography.titleMedium,
+)
+Slider(
+    value = behindPaceHour.toFloat(),
+    onValueChange = { viewModel.updateBehindPaceCheckHour(it.toInt()) },
+    valueRange = 0f..23f,
+    steps = 22,
+    modifier = Modifier.fillMaxWidth(),
+)
+Text(
+    "Time of day to check whether you're behind your step goal.",
+    style = MaterialTheme.typography.bodySmall,
+)
+Spacer(Modifier.height(16.dp))
+```
+
+- [ ] **Step 6.3: Build**
+
+Run: `./gradlew :mobile:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt \
+        mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsScreen.kt
+git commit -m "feat: add behindPaceCheckHour slider to SettingsScreen (#23)"
+```
+
+---
+
+## Task 7: `PhoneSettingsSyncer.syncNow` — TDD (red → green)
+
+**Files:**
+- Create: `mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt`
+- Create: `mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt`
+
+We need to inject a mockable `DataClient`. The cleanest pattern is a small functional abstraction; testing the real `Wearable.getDataClient(context)` requires an emulator. We'll introduce a single-method interface that production satisfies with a thin lambda.
+
+- [ ] **Step 7.1: Write the failing syncNow test**
+
+```kotlin
+package com.meatsack.motivator.mobile.sync
+
+import com.google.android.gms.wearable.DataMap
+import com.google.android.gms.wearable.PutDataRequest
+import com.meatsack.motivator.mobile.data.SettingsRepository
+import com.meatsack.shared.sync.SettingsDefaults
+import com.meatsack.shared.sync.SettingsKeys
+import com.meatsack.shared.sync.SettingsSnapshot
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class PhoneSettingsSyncerTest {
+
+    /** Captures the last PutDataRequest the syncer attempted to send. */
+    private class FakeDataItemSink : DataItemSink {
+        var lastRequest: PutDataRequest? = null
+        var failNextWith: Throwable? = null
+        var callCount = 0
+        override suspend fun put(request: PutDataRequest) {
+            callCount++
+            failNextWith?.let { failNextWith = null; throw it }
+            lastRequest = request
+        }
+    }
+
+    @Test
+    fun syncNow_writesPutDataRequest_atSettingsPath_withAllKeys() = runTest {
+        val sink = FakeDataItemSink()
+        val syncer = PhoneSettingsSyncer(
+            settings = FakeSettingsSource(SettingsSnapshot.defaults.copy(dailyStepGoal = 12345)),
+            sink = sink,
+        )
+
+        syncer.syncNow()
+
+        val req = sink.lastRequest
+        assertNotNull("expected a PutDataRequest", req)
+        assertEquals(SettingsKeys.PATH, req!!.uri.path)
+        val parsed = SettingsSnapshot.fromDataMap(
+            com.google.android.gms.wearable.PutDataMapRequest.createFromDataMapItem(
+                com.google.android.gms.wearable.DataMapItem.fromDataItem(
+                    com.google.android.gms.wearable.DataItem { req.uri }
+                )
+            ).dataMap // see note below
+        )
+        // The above two-step parse is awkward; the simpler shape is to verify
+        // the DataMap directly. We'll prefer that approach in the implementation
+        // — see Step 7.3 for a tighter helper. For now, accept that the test
+        // above documents the expected behavior even if its parse is verbose.
+        assertEquals(12345, parsed.dailyStepGoal)
+    }
+
+    private class FakeSettingsSource(snap: SettingsSnapshot) : SettingsSource {
+        override val flow = MutableStateFlow(snap)
+        override suspend fun current(): SettingsSnapshot = flow.value
+    }
+}
+```
+
+**Note:** the DataItem reconstruction shape above is intentionally clunky to flag a simpler design: keep the test's assertion in terms of `DataMap` rather than `DataItem`, by having the sink expose the `DataMap` it received rather than a fully-built `PutDataRequest`. We'll adjust the abstraction in Step 7.3.
+
+- [ ] **Step 7.2: Run the test, expecting compile failure**
+
+Run: `./gradlew :mobile:testDebugUnitTest --tests "com.meatsack.motivator.mobile.sync.PhoneSettingsSyncerTest"`
+
+Expected: COMPILE FAILURE — `Unresolved reference: PhoneSettingsSyncer`, `SettingsSource`, `DataItemSink`. Good — proceed.
+
+- [ ] **Step 7.3: Simplify the abstraction, rewrite the test**
+
+We'll make the sink hand-off a `DataMap` directly so tests don't need to reconstruct DataItems. Replace the test with:
+
+```kotlin
+package com.meatsack.motivator.mobile.sync
+
+import com.google.android.gms.wearable.DataMap
+import com.meatsack.shared.sync.SettingsDefaults
+import com.meatsack.shared.sync.SettingsKeys
+import com.meatsack.shared.sync.SettingsSnapshot
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class PhoneSettingsSyncerTest {
+
+    private class FakeSink : SettingsSink {
+        var lastDataMap: DataMap? = null
+        var callCount = 0
+        var failNextWith: Throwable? = null
+        override suspend fun put(path: String, dataMap: DataMap) {
+            callCount++
+            failNextWith?.let { failNextWith = null; throw it }
+            assertEquals(SettingsKeys.PATH, path)
+            lastDataMap = dataMap
+        }
+    }
+
+    private class FakeSettingsSource(initial: SettingsSnapshot) : SettingsSource {
+        override val snapshots = MutableStateFlow(initial)
+        override suspend fun current(): SettingsSnapshot = snapshots.value
+    }
+
+    @Test
+    fun syncNow_writesAllFieldsAtSettingsPath() = runTest {
+        val custom = SettingsSnapshot.defaults.copy(
+            dailyStepGoal = 12345,
+            inactivityThreshold = 45,
+            behindPaceCheckHour = 14,
+        )
+        val sink = FakeSink()
+        val syncer = PhoneSettingsSyncer(FakeSettingsSource(custom), sink)
+
+        syncer.syncNow()
+
+        val dm = sink.lastDataMap
+        assertNotNull("expected sink to receive a DataMap", dm)
+        val parsed = SettingsSnapshot.fromDataMap(dm!!)
+        assertEquals(custom, parsed)
+        assertEquals(1, sink.callCount)
+    }
+
+    @Test
+    fun syncNow_propagatesCancellation() = runTest {
+        val sink = FakeSink().apply { failNextWith = kotlinx.coroutines.CancellationException("test") }
+        val syncer = PhoneSettingsSyncer(FakeSettingsSource(SettingsSnapshot.defaults), sink)
+        var threw = false
+        try {
+            syncer.syncNow()
+        } catch (_: kotlinx.coroutines.CancellationException) {
+            threw = true
+        }
+        assert(threw) { "syncNow should rethrow CancellationException" }
+    }
+
+    @Test
+    fun syncNow_swallowsAndLogsOtherExceptions() = runTest {
+        val sink = FakeSink().apply { failNextWith = RuntimeException("network down") }
+        val syncer = PhoneSettingsSyncer(FakeSettingsSource(SettingsSnapshot.defaults), sink)
+        syncer.syncNow() // should not throw
+        // Nothing else to assert — no exception is the success criterion.
+    }
+}
+```
+
+- [ ] **Step 7.4: Implement `PhoneSettingsSyncer` + abstractions**
+
+Create `mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt`:
+
+```kotlin
+package com.meatsack.motivator.mobile.sync
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.DataMap
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import com.meatsack.motivator.mobile.data.SettingsRepository
+import com.meatsack.shared.sync.SettingsKeys
+import com.meatsack.shared.sync.SettingsSnapshot
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Source of SettingsSnapshot updates. Production wires this to combine() over
+ * SettingsRepository flows; tests use an in-memory MutableStateFlow.
+ */
+interface SettingsSource {
+    val snapshots: Flow<SettingsSnapshot>
+    suspend fun current(): SettingsSnapshot
+}
+
+/**
+ * Single-method abstraction over the Wear DataClient. Production wraps
+ * Wearable.getDataClient(context).putDataItem(...); tests fake it.
+ */
+interface SettingsSink {
+    suspend fun put(path: String, dataMap: DataMap)
+}
+
+class PhoneSettingsSyncer(
+    private val settings: SettingsSource,
+    private val sink: SettingsSink,
+) {
+
+    companion object {
+        private const val TAG = "PhoneSettingsSyncer"
+    }
+
+    suspend fun syncNow() {
+        val snap = settings.current()
+        writeSnapshot(snap)
+    }
+
+    private suspend fun writeSnapshot(snap: SettingsSnapshot) {
+        try {
+            val dm = DataMap()
+            snap.toDataMap(dm)
+            sink.put(SettingsKeys.PATH, dm)
+            Log.d(TAG, "Synced settings: $snap")
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (e: Exception) {
+            Log.e(TAG, "Settings sync failed", e)
+        }
+    }
+}
+```
+
+- [ ] **Step 7.5: Run tests**
+
+Run: `./gradlew :mobile:testDebugUnitTest --tests "com.meatsack.motivator.mobile.sync.PhoneSettingsSyncerTest"`
+
+Expected: 3 tests pass.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt \
+        mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
+git commit -m "feat: PhoneSettingsSyncer.syncNow + injectable Source/Sink (#23)"
+```
+
+---
+
+## Task 8: `PhoneSettingsSyncer.start` — debounce, distinctUntilChanged, retry
+
+**Files:**
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt`
+- Modify: `mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt`
+
+We use `kotlinx-coroutines-test`'s virtual time to verify debouncing without sleeping.
+
+- [ ] **Step 8.1: Verify `kotlinx-coroutines-test` is available**
+
+Run: `grep -n "kotlinx-coroutines-test" mobile/build.gradle.kts`
+
+If no result, add to dependencies in `mobile/build.gradle.kts`:
+
+```kotlin
+testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+```
+
+(Use the version matching the other kotlinx-coroutines artifacts in the project.)
+
+- [ ] **Step 8.2: Write the failing debounce + distinctUntilChanged test**
+
+Append to `PhoneSettingsSyncerTest.kt`:
+
+```kotlin
+@Test
+fun start_debouncesRapidEmissionsToSingleWrite() = runTest {
+    val source = FakeSettingsSource(SettingsSnapshot.defaults)
+    val sink = FakeSink()
+    val syncer = PhoneSettingsSyncer(source, sink)
+
+    val job = launch { syncer.start(this) }
+
+    // Three rapid edits within the 500ms debounce window — should collapse to one write.
+    source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 11000)
+    advanceTimeBy(100)
+    source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 12000)
+    advanceTimeBy(100)
+    source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 13000)
+    advanceTimeBy(600) // > debounce window
+
+    assertEquals("expected only the trailing emission to be written", 1, sink.callCount)
+    val parsed = SettingsSnapshot.fromDataMap(sink.lastDataMap!!)
+    assertEquals(13000, parsed.dailyStepGoal)
+
+    job.cancel()
+}
+
+@Test
+fun start_distinctUntilChanged_suppressesIdenticalEmissions() = runTest {
+    val source = FakeSettingsSource(SettingsSnapshot.defaults)
+    val sink = FakeSink()
+    val syncer = PhoneSettingsSyncer(source, sink)
+
+    val job = launch { syncer.start(this) }
+
+    source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 11000)
+    advanceTimeBy(600)
+    source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 11000) // identical
+    advanceTimeBy(600)
+
+    assertEquals(1, sink.callCount)
+    job.cancel()
+}
+```
+
+Add the necessary imports at the top of the test file:
+
+```kotlin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+```
+
+- [ ] **Step 8.3: Run, expecting compile failure**
+
+Run: `./gradlew :mobile:testDebugUnitTest --tests "com.meatsack.motivator.mobile.sync.PhoneSettingsSyncerTest"`
+
+Expected: COMPILE FAILURE — `start` is not yet defined. Proceed.
+
+- [ ] **Step 8.4: Implement `start`**
+
+In `PhoneSettingsSyncer.kt`, add the imports:
+
+```kotlin
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+```
+
+Replace the class body so it reads:
+
+```kotlin
+class PhoneSettingsSyncer(
+    private val settings: SettingsSource,
+    private val sink: SettingsSink,
+) {
+
+    companion object {
+        private const val TAG = "PhoneSettingsSyncer"
+        private const val MAX_RETRY_ATTEMPTS = 3
+    }
+
+    fun start(scope: CoroutineScope) {
+        scope.launch {
+            settings.snapshots
+                .debounce(500.milliseconds)
+                .distinctUntilChanged()
+                .retryWhen { cause, attempt ->
+                    if (attempt < MAX_RETRY_ATTEMPTS) {
+                        Log.w(TAG, "settings flow failure (attempt=$attempt), retrying", cause)
+                        delay(((1L shl attempt.toInt()).coerceAtMost(8)).seconds)
+                        true
+                    } else {
+                        Log.e(TAG, "settings flow gave up after $MAX_RETRY_ATTEMPTS retries", cause)
+                        false
+                    }
+                }
+                .catch { e -> Log.e(TAG, "settings flow terminated", e) }
+                .collect { snap -> writeSnapshot(snap) }
+        }
+    }
+
+    suspend fun syncNow() {
+        writeSnapshot(settings.current())
+    }
+
+    private suspend fun writeSnapshot(snap: SettingsSnapshot) {
+        try {
+            val dm = DataMap()
+            snap.toDataMap(dm)
+            sink.put(SettingsKeys.PATH, dm)
+            Log.d(TAG, "Synced settings: $snap")
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (e: Exception) {
+            Log.e(TAG, "Settings sync failed", e)
+        }
+    }
+}
+```
+
+(Notice `start` accepts a `CoroutineScope` instead of being a `suspend` function. This matches the call site `start(applicationScope)` in `MeatsackMobileApp.onCreate`.)
+
+- [ ] **Step 8.5: Run tests**
+
+Run: `./gradlew :mobile:testDebugUnitTest --tests "com.meatsack.motivator.mobile.sync.PhoneSettingsSyncerTest"`
+
+Expected: all 5 tests pass (3 from Task 7 + 2 new).
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt \
+        mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
+# include mobile/build.gradle.kts if Step 8.1 needed an add:
+# git add mobile/build.gradle.kts
+git commit -m "feat: PhoneSettingsSyncer.start with debounce + retryWhen (#23)"
+```
+
+---
+
+## Task 9: Production `SettingsSource` + `SettingsSink` + wire into `MeatsackMobileApp` + `MainActivity.onResume`
+
+**Files:**
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt` (add factories)
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/MeatsackMobileApp.kt`
+- Modify: `mobile/src/main/java/com/meatsack/motivator/mobile/MainActivity.kt`
+
+- [ ] **Step 9.1: Add production `SettingsSource` and `SettingsSink` to `PhoneSettingsSyncer.kt`**
+
+Append to `PhoneSettingsSyncer.kt`, below the class:
+
+```kotlin
+/**
+ * Production SettingsSource backed by SettingsRepository. Combines the 7
+ * watch-relevant Flows into a single SettingsSnapshot.
+ */
+class RepositorySettingsSource(private val repo: SettingsRepository) : SettingsSource {
+    override val snapshots: Flow<SettingsSnapshot> = kotlinx.coroutines.flow.combine(
+        repo.dailyStepGoal,
+        repo.inactivityThreshold,
+        repo.activeHoursStart,
+        repo.activeHoursEnd,
+        repo.contextAwareEnabled,
+        repo.endOfDayHour,
+        repo.behindPaceCheckHour,
+    ) { values ->
+        SettingsSnapshot(
+            dailyStepGoal = values[0] as Int,
+            inactivityThreshold = values[1] as Int,
+            activeHoursStart = values[2] as Int,
+            activeHoursEnd = values[3] as Int,
+            contextAwareEnabled = values[4] as Boolean,
+            endOfDayHour = values[5] as Int,
+            behindPaceCheckHour = values[6] as Int,
+        )
+    }
+
+    override suspend fun current(): SettingsSnapshot =
+        SettingsSnapshot(
+            dailyStepGoal = kotlinx.coroutines.flow.first(repo.dailyStepGoal),
+            inactivityThreshold = kotlinx.coroutines.flow.first(repo.inactivityThreshold),
+            activeHoursStart = kotlinx.coroutines.flow.first(repo.activeHoursStart),
+            activeHoursEnd = kotlinx.coroutines.flow.first(repo.activeHoursEnd),
+            contextAwareEnabled = kotlinx.coroutines.flow.first(repo.contextAwareEnabled),
+            endOfDayHour = kotlinx.coroutines.flow.first(repo.endOfDayHour),
+            behindPaceCheckHour = kotlinx.coroutines.flow.first(repo.behindPaceCheckHour),
+        )
+}
+
+/** Production sink that writes via Wearable.getDataClient. */
+class WearableSettingsSink(private val context: Context) : SettingsSink {
+    override suspend fun put(path: String, dataMap: DataMap) {
+        val req = PutDataMapRequest.create(path).apply {
+            this.dataMap.putAll(dataMap)
+        }.asPutDataRequest().setUrgent()
+        Wearable.getDataClient(context).putDataItem(req).await()
+    }
+}
+```
+
+**Note:** the `first` call shape above uses the top-level operator. If your project has it under a different import (e.g., extension on Flow), adjust accordingly — the alternative shape is:
+
+```kotlin
+import kotlinx.coroutines.flow.first
+// ...
+override suspend fun current(): SettingsSnapshot =
+    SettingsSnapshot(
+        dailyStepGoal = repo.dailyStepGoal.first(),
+        // ...etc
+    )
+```
+
+Use whichever import shape matches the project's idioms (check existing code via `grep -rn "\.first()" mobile/src/main`). The extension shape is more idiomatic Kotlin.
+
+- [ ] **Step 9.2: Wire into `MeatsackMobileApp`**
+
+Modify `mobile/src/main/java/com/meatsack/motivator/mobile/MeatsackMobileApp.kt`:
+
+Add imports:
+
+```kotlin
+import com.meatsack.motivator.mobile.data.SettingsRepository
+import com.meatsack.motivator.mobile.sync.PhoneSettingsSyncer
+import com.meatsack.motivator.mobile.sync.RepositorySettingsSource
+import com.meatsack.motivator.mobile.sync.WearableSettingsSink
+```
+
+In the class body, after `applicationScope`, add:
+
+```kotlin
+lateinit var settingsSyncer: PhoneSettingsSyncer
+    private set
+```
+
+In `onCreate()`, after `seedDatabaseIfEmpty()`, add:
+
+```kotlin
+val repo = SettingsRepository(this)
+settingsSyncer = PhoneSettingsSyncer(
+    settings = RepositorySettingsSource(repo),
+    sink = WearableSettingsSink(this),
+)
+settingsSyncer.start(applicationScope)
+Log.d(TAG, "PhoneSettingsSyncer started")
+```
+
+- [ ] **Step 9.3: Call `syncNow()` from `MainActivity.onResume`**
+
+Modify `mobile/src/main/java/com/meatsack/motivator/mobile/MainActivity.kt`:
+
+Replace the file contents with:
+
+```kotlin
+package com.meatsack.motivator.mobile
+
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.lifecycle.lifecycleScope
+import com.meatsack.motivator.mobile.ui.navigation.MeatsackNavGraph
+import kotlinx.coroutines.launch
+
+class MainActivity : ComponentActivity() {
+
+    companion object {
+        private const val TAG = "MainActivity"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                MeatsackNavGraph()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val app = applicationContext as MeatsackMobileApp
+        lifecycleScope.launch {
+            try {
+                app.settingsSyncer.syncNow()
+            } catch (t: Throwable) {
+                Log.w(TAG, "onResume syncNow failed", t)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 9.4: Build**
+
+Run: `./gradlew :mobile:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt \
+        mobile/src/main/java/com/meatsack/motivator/mobile/MeatsackMobileApp.kt \
+        mobile/src/main/java/com/meatsack/motivator/mobile/MainActivity.kt
+git commit -m "feat: wire PhoneSettingsSyncer into Application + onResume (#23)"
+```
+
+---
+
+## Task 10: Add `inactivityThreshold` to `WatchSettingsCache`
+
+**Files:**
+- Modify: `wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt`
+
+No new test file — `WatchSettingsCache` has SharedPreferences-backed properties; Robolectric would be required to exercise them in isolation. We'll cover the wiring via `EscalationManagerTest` (Task 11) and the manual E2E checklist.
+
+- [ ] **Step 10.1: Add the field**
+
+In `WatchSettingsCache.kt`, alongside the other `var` properties, add:
+
+```kotlin
+var inactivityThreshold: Int
+    get() = prefs.getInt(KEY_INACTIVITY_THRESHOLD, SettingsDefaults.INACTIVITY_THRESHOLD_MIN)
+    set(value) = prefs.edit().putInt(KEY_INACTIVITY_THRESHOLD, value).apply()
+```
+
+In the `companion object`, alongside the other key constants, add:
+
+```kotlin
+private const val KEY_INACTIVITY_THRESHOLD = "inactivity_threshold_min"
+```
+
+- [ ] **Step 10.2: Build**
+
+Run: `./gradlew :wear:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 10.3: Commit**
+
+```bash
+git add wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
+git commit -m "feat: add inactivityThreshold to WatchSettingsCache (#23)"
+```
+
+---
+
+## Task 11: Rewire `EscalationManager` to read threshold from a provider
+
+**Files:**
+- Modify: `wear/src/main/java/com/meatsack/motivator/escalation/EscalationManager.kt`
+- Modify: `wear/src/test/java/com/meatsack/motivator/escalation/EscalationManagerTest.kt`
+- Modify: `wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt`
+
+- [ ] **Step 11.1: Write the failing test**
+
+Append to `EscalationManagerTest.kt` (note: keep the default-arg test for the existing `EscalationManager()` ctor path):
+
+```kotlin
+@Test
+fun `custom threshold provider overrides default`() {
+    val customManager = EscalationManager(thresholdProvider = { 45 })
+    assertFalse("44 is below custom threshold 45", customManager.shouldTrigger(44))
+    assertTrue("45 should trigger", customManager.shouldTrigger(45))
+}
+
+@Test
+fun `provider is called per shouldTrigger invocation (live config)`() {
+    var threshold = 30
+    val liveManager = EscalationManager(thresholdProvider = { threshold })
+    assertTrue("30 triggers with threshold=30", liveManager.shouldTrigger(30))
+    liveManager.onMovementDetected() // reset
+    threshold = 60
+    assertFalse("30 should not trigger after raising threshold to 60", liveManager.shouldTrigger(30))
+    assertTrue("60 triggers with threshold=60", liveManager.shouldTrigger(60))
+}
+```
+
+- [ ] **Step 11.2: Run the test, expecting compile failure**
+
+Run: `./gradlew :wear:testDebugUnitTest --tests "com.meatsack.motivator.escalation.EscalationManagerTest"`
+
+Expected: COMPILE FAILURE — `EscalationManager` has no `thresholdProvider` parameter.
+
+- [ ] **Step 11.3: Modify `EscalationManager`**
+
+In `EscalationManager.kt`:
+
+Add import:
+
+```kotlin
+import com.meatsack.shared.sync.SettingsDefaults
+```
+
+Change the class declaration from:
+
+```kotlin
+class EscalationManager {
+```
+
+to:
+
+```kotlin
+class EscalationManager(
+    private val thresholdProvider: () -> Int = { SettingsDefaults.INACTIVITY_THRESHOLD_MIN },
+) {
+```
+
+Replace `EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT` with `thresholdProvider()` on both lines (currently 57 and 67):
+
+```kotlin
+val threshold = thresholdProvider()
+```
+
+Leave `EscalationLevel.ESCALATION_INTERVAL_MINUTES` references untouched.
+
+- [ ] **Step 11.4: Run tests**
+
+Run: `./gradlew :wear:testDebugUnitTest --tests "com.meatsack.motivator.escalation.EscalationManagerTest"`
+
+Expected: all tests pass (the existing `EscalationManager()` ctor still works via the default arg).
+
+- [ ] **Step 11.5: Wire production threshold provider in `MeatsackWearService`**
+
+Open `wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt`. Find the construction of `EscalationManager` (it should currently be a no-arg `EscalationManager()`).
+
+Replace it with:
+
+```kotlin
+EscalationManager(thresholdProvider = { watchSettingsCache.inactivityThreshold })
+```
+
+If `watchSettingsCache` is not yet declared in scope where `EscalationManager` is built, hoist its construction earlier in the function — `WatchSettingsCache` is constructed from `Context`, so it's a one-liner. (Look near the existing `WatchSettingsCache(this)` construction site as a reference.)
+
+- [ ] **Step 11.6: Build wear**
+
+Run: `./gradlew :wear:compileDebugKotlin :wear:testDebugUnitTest`
+Expected: all green.
+
+- [ ] **Step 11.7: Commit**
+
+```bash
+git add wear/src/main/java/com/meatsack/motivator/escalation/EscalationManager.kt \
+        wear/src/test/java/com/meatsack/motivator/escalation/EscalationManagerTest.kt \
+        wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
+git commit -m "feat: EscalationManager reads inactivityThreshold from cache (#23)"
+```
+
+---
+
+## Task 12: `WatchSettingsReceiver` — TDD via factored `applySnapshot`
+
+**Files:**
+- Create: `wear/src/main/java/com/meatsack/motivator/sync/WatchSettingsReceiver.kt`
+- Create: `wear/src/test/java/com/meatsack/motivator/sync/WatchSettingsReceiverTest.kt`
+- Modify: `wear/src/main/AndroidManifest.xml`
+
+We extract the "apply each field to the cache" logic into a pure function operating on a small `SettingsSink` interface (separate from the phone-side `SettingsSink` — keep names distinct; we'll call this one `SettingsApplySink` or use a sealed interface). To avoid name collision, the watch-side sink will live in the same `wear/sync` package and have a different name.
+
+- [ ] **Step 12.1: Write the failing test**
+
+```kotlin
+package com.meatsack.motivator.sync
+
+import com.meatsack.shared.sync.SettingsSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WatchSettingsReceiverTest {
+
+    /** Map-backed fake that records all writes. */
+    private class FakeApplySink : WatchSettingsReceiver.ApplySink {
+        var dailyStepGoal: Int = -1
+        var inactivityThreshold: Int = -1
+        var activeHoursStart: Int = -1
+        var activeHoursEnd: Int = -1
+        var contextAwareEnabled: Boolean = false
+        var endOfDayHour: Int = -1
+        var behindPaceCheckHour: Int = -1
+        override fun setDailyStepGoal(v: Int) { dailyStepGoal = v }
+        override fun setInactivityThreshold(v: Int) { inactivityThreshold = v }
+        override fun setActiveHoursStart(v: Int) { activeHoursStart = v }
+        override fun setActiveHoursEnd(v: Int) { activeHoursEnd = v }
+        override fun setContextAwareEnabled(v: Boolean) { contextAwareEnabled = v }
+        override fun setEndOfDayHour(v: Int) { endOfDayHour = v }
+        override fun setBehindPaceCheckHour(v: Int) { behindPaceCheckHour = v }
+    }
+
+    @Test
+    fun applySnapshot_writesEveryField() {
+        val sink = FakeApplySink()
+        val snap = SettingsSnapshot(
+            dailyStepGoal = 12_000,
+            inactivityThreshold = 45,
+            activeHoursStart = 8,
+            activeHoursEnd = 21,
+            contextAwareEnabled = true,
+            endOfDayHour = 20,
+            behindPaceCheckHour = 14,
+        )
+        WatchSettingsReceiver.applySnapshot(snap, sink)
+        assertEquals(12_000, sink.dailyStepGoal)
+        assertEquals(45, sink.inactivityThreshold)
+        assertEquals(8, sink.activeHoursStart)
+        assertEquals(21, sink.activeHoursEnd)
+        assertEquals(true, sink.contextAwareEnabled)
+        assertEquals(20, sink.endOfDayHour)
+        assertEquals(14, sink.behindPaceCheckHour)
+    }
+}
+```
+
+- [ ] **Step 12.2: Run, expecting compile failure**
+
+Run: `./gradlew :wear:testDebugUnitTest --tests "com.meatsack.motivator.sync.WatchSettingsReceiverTest"`
+
+Expected: COMPILE FAILURE — `WatchSettingsReceiver` doesn't exist.
+
+- [ ] **Step 12.3: Implement `WatchSettingsReceiver`**
+
+```kotlin
+package com.meatsack.motivator.sync
+
+import android.util.Log
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.WearableListenerService
+import com.meatsack.motivator.settings.WatchSettingsCache
+import com.meatsack.shared.sync.SettingsKeys
+import com.meatsack.shared.sync.SettingsSnapshot
+
+class WatchSettingsReceiver : WearableListenerService() {
+
+    companion object {
+        private const val TAG = "WatchSettingsReceiver"
+
+        /**
+         * Pure function. Apply the snapshot field-by-field to the sink.
+         * Extracted so unit tests don't need a WearableListenerService instance.
+         */
+        fun applySnapshot(snap: SettingsSnapshot, sink: ApplySink) {
+            sink.setDailyStepGoal(snap.dailyStepGoal)
+            sink.setInactivityThreshold(snap.inactivityThreshold)
+            sink.setActiveHoursStart(snap.activeHoursStart)
+            sink.setActiveHoursEnd(snap.activeHoursEnd)
+            sink.setContextAwareEnabled(snap.contextAwareEnabled)
+            sink.setEndOfDayHour(snap.endOfDayHour)
+            sink.setBehindPaceCheckHour(snap.behindPaceCheckHour)
+        }
+    }
+
+    /** Minimal write surface that WatchSettingsCache satisfies via cacheAdapter(). */
+    interface ApplySink {
+        fun setDailyStepGoal(v: Int)
+        fun setInactivityThreshold(v: Int)
+        fun setActiveHoursStart(v: Int)
+        fun setActiveHoursEnd(v: Int)
+        fun setContextAwareEnabled(v: Boolean)
+        fun setEndOfDayHour(v: Int)
+        fun setBehindPaceCheckHour(v: Int)
+    }
+
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        dataEvents.forEach { event ->
+            val path = event.dataItem.uri.path
+            if (path != SettingsKeys.PATH) return@forEach
+            val sourceNode = event.dataItem.uri.host
+            try {
+                val dm = DataMapItem.fromDataItem(event.dataItem).dataMap
+                val snap = SettingsSnapshot.fromDataMap(dm)
+                val cache = WatchSettingsCache(applicationContext)
+                applySnapshot(snap, cacheAdapter(cache))
+                Log.d(TAG, "Applied settings from node=$sourceNode: $snap")
+            } catch (t: Throwable) {
+                Log.e(TAG, "Failed to apply settings from node=$sourceNode", t)
+            }
+        }
+    }
+
+    private fun cacheAdapter(cache: WatchSettingsCache): ApplySink = object : ApplySink {
+        override fun setDailyStepGoal(v: Int) { cache.dailyStepGoal = v }
+        override fun setInactivityThreshold(v: Int) { cache.inactivityThreshold = v }
+        override fun setActiveHoursStart(v: Int) { cache.activeHoursStart = v }
+        override fun setActiveHoursEnd(v: Int) { cache.activeHoursEnd = v }
+        override fun setContextAwareEnabled(v: Boolean) { cache.contextAwareEnabled = v }
+        override fun setEndOfDayHour(v: Int) { cache.endOfDayHour = v }
+        override fun setBehindPaceCheckHour(v: Int) { cache.behindPaceCheckHour = v }
+    }
+}
+```
+
+- [ ] **Step 12.4: Register receiver in `AndroidManifest.xml`**
+
+Open `wear/src/main/AndroidManifest.xml`. Find the existing `WatchSyncReceiver` registration and locate its pattern. Add an adjacent `<service>` element for `WatchSettingsReceiver` with a `<data-item-filter>` for the `/settings` path. The structure should mirror the existing receiver. For reference, the form is approximately:
+
+```xml
+<service
+    android:name=".sync.WatchSettingsReceiver"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+        <data
+            android:scheme="wear"
+            android:host="*"
+            android:pathPrefix="/settings" />
+    </intent-filter>
+</service>
+```
+
+(Verify the exact tag shapes against the existing `WatchSyncReceiver` block — the path attribute name in particular may be `android:path` rather than `android:pathPrefix` depending on what the existing entry uses.)
+
+- [ ] **Step 12.5: Run tests + build**
+
+Run: `./gradlew :wear:testDebugUnitTest --tests "com.meatsack.motivator.sync.WatchSettingsReceiverTest" :wear:compileDebugKotlin`
+Expected: test passes, BUILD SUCCESSFUL.
+
+- [ ] **Step 12.6: Commit**
+
+```bash
+git add wear/src/main/java/com/meatsack/motivator/sync/WatchSettingsReceiver.kt \
+        wear/src/test/java/com/meatsack/motivator/sync/WatchSettingsReceiverTest.kt \
+        wear/src/main/AndroidManifest.xml
+git commit -m "feat: WatchSettingsReceiver consumes /settings DataItem (#23)"
+```
+
+---
+
+## Task 13: Full build + unit tests + manual end-to-end smoke
+
+**Files:** none modified.
+
+- [ ] **Step 13.1: Full build**
+
+Run: `./gradlew build`
+Expected: BUILD SUCCESSFUL across all modules. spotlessCheck must pass (run `./gradlew spotlessApply && git add -u` if it complains).
+
+- [ ] **Step 13.2: Full unit test sweep**
+
+Run: `./gradlew :shared:testDebugUnitTest :mobile:testDebugUnitTest :wear:testDebugUnitTest`
+Expected: all green.
+
+- [ ] **Step 13.3: Install on paired emulators**
+
+Confirm the phone (`emulator-5554`) and watch (`emulator-5556`) emulators are paired via Android Studio's Pair Wearable wizard; verify with:
+
+```bash
+adb -s emulator-5554 shell dumpsys activity service com.google.android.gms/.wearable.service.WearableService | grep "connected out of"
+```
+
+Expected: `1 connected out of 1`. If not, re-run the pairing wizard (or `adb -s emulator-5554 forward tcp:5601 tcp:5601` if it's just the tunnel that dropped).
+
+Then:
+
+```bash
+./gradlew :mobile:installDebug :wear:installDebug
+adb -s emulator-5556 shell pm grant com.meatsack.motivator android.permission.ACTIVITY_RECOGNITION
+```
+
+- [ ] **Step 13.4: Manual E2E checklist**
+
+1. Tail watch logcat: `adb -s emulator-5556 logcat -s WatchSettingsReceiver:V WatchSettingsCache:V`
+2. Tail phone logcat: `adb -s emulator-5554 logcat -s PhoneSettingsSyncer:V MainActivity:V`
+3. Launch phone app. Confirm phone logcat shows `PhoneSettingsSyncer started` then a `Synced settings: SettingsSnapshot(...)` shortly after (from the `onResume → syncNow` path).
+4. Open the Settings tab. Drag the `Daily step goal` slider to 12000.
+5. Within ~2 seconds, watch logcat should show `Applied settings from node=...: SettingsSnapshot(dailyStepGoal=12000, ...)`.
+6. Adjust `Behind-pace check hour` slider. Verify another apply log on the watch.
+7. Toggle the `Context-aware language` switch. Verify the boolean propagated.
+8. Force-stop the phone app, relaunch — confirm one more `Synced settings: ...` log fires from `onResume`.
+9. Open the watch app. Inactivity simulation (drop `EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT` to 1 temporarily per CLAUDE.md guidance, OR simply trust the unit tests for the `EscalationManager` rewire) — verify the inactivity threshold the watch uses now reflects the phone setting if you changed it.
+
+- [ ] **Step 13.5: Push the branch**
+
+```bash
+git push -u origin feature/phone-watch-settings-sync
+```
+
+- [ ] **Step 13.6: Open the PR**
+
+```bash
+gh pr create --title "Phone→watch settings sync via /settings DataItem (closes #23)" --body "$(cat <<'EOF'
+## Summary
+- Adds a `/settings` Wear Data Layer channel carrying the 7 watch-relevant settings via DataMap-native typed keys.
+- New shared types: `SettingsKeys`, `SettingsSnapshot` (with `toDataMap`/`fromDataMap` + `coerceIn(0..23)` for hour fields), and hoisted `SettingsDefaults` — single source of truth that makes future schema drift a compile error.
+- `PhoneSettingsSyncer` observes `SettingsRepository` flows (debounce 500ms + distinctUntilChanged + bounded retryWhen) and exposes `syncNow()` called from `MainActivity.onResume`.
+- `WatchSettingsReceiver` consumes `/settings` and applies into `WatchSettingsCache`. Pure `applySnapshot` factored for unit testing.
+- Adds `behindPaceCheckHour` slider to phone UI (was watch-only).
+- Rewires `EscalationManager` to read `inactivityThreshold` from `WatchSettingsCache` via injected `thresholdProvider: () -> Int` (was hardcoded to `EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT`).
+
+Closes #23. Partially addresses #25 (defense-in-depth `coerceIn` on the wire).
+
+## Test plan
+- [x] `./gradlew :shared:testDebugUnitTest :mobile:testDebugUnitTest :wear:testDebugUnitTest` all pass
+- [x] `./gradlew build` (including spotlessCheck) passes
+- [x] Manual E2E on paired emulators per spec checklist: phone slider edits propagate to watch within ~2 sec; force-stop + relaunch fires one more snapshot; toggles + hour pickers all propagate.
+
+## Spec
+`docs/superpowers/specs/2026-05-30-phone-watch-settings-sync-design.md`
+EOF
+)"
+```
+
+- [ ] **Step 13.7: Per-project workflow, run the PR review skill**
+
+After the PR is created, hand off to the `pr-review-toolkit:review-pr` skill against the new PR number (the user's CLAUDE.md / memory rule: "Review every PR" — after `gh pr create`, invoke the review skill before declaring done).
+
+---
+
+## Risks / known unknowns flagged inline
+
+- **DataMap pure-JVM instantiation:** Task 3 verifies. If it fails, Task 4 Step 4.3 adds Robolectric to `:shared/src/test`. Cost: one extra dep declaration.
+- **AndroidManifest filter shape:** Task 12 Step 12.4 — verify against the existing `WatchSyncReceiver` entry. If the existing entry uses `android:path` not `android:pathPrefix`, mirror that.
+- **`first` import shape:** Task 9 Step 9.1 — both top-level and extension forms exist in `kotlinx-coroutines-core`. Use whichever matches project idioms (`grep -rn "\.first()" mobile/src/main`).
+- **`MeatsackWearService` `EscalationManager` call site:** Task 11 Step 11.5 — the exact construction site may need `WatchSettingsCache` hoisted earlier in the function. Investigate first; the fix is small.
+
+---
+
+## Out of scope (deliberately deferred — track separately)
+
+- Phone-side surfacing of setter validation failures (#21).
+- Worker silent-failure hardening (#24).
+- `WatchSettingsCache.coerceIn(0..23)` defense at *read* time (#25; we cover the *wire* coerce here but not the cache).
+- Deciding whether/how `quietHoursStart`/`quietHoursEnd` should reach the watch (file new issue).
+- Surfacing `endOfDayHour` in the phone UI (the `SettingsViewModel` exposes it but `SettingsScreen.kt` has no picker for it — discovered while writing this plan, file new issue).

--- a/docs/superpowers/specs/2026-05-30-phone-watch-settings-sync-design.md
+++ b/docs/superpowers/specs/2026-05-30-phone-watch-settings-sync-design.md
@@ -1,0 +1,254 @@
+# Phone → Watch Settings Sync — Design
+
+> **Status:** approved design, pre-implementation.
+> **Closes:** [#23](https://github.com/xhf2/meatsackMotivator/issues/23).
+> **Partially addresses:** [#25](https://github.com/xhf2/meatsackMotivator/issues/25) (defense-in-depth `coerceIn`).
+
+## Problem
+
+The watch reads user settings from `WatchSettingsCache` (a watch-local `SharedPreferences` cache), but nothing populates that cache from the phone. The `WatchSettingsCache` KDoc still references a "future settings-sync DataItem (Task 16)" that was never built. Today the user sees:
+
+| Setting | Phone UI lets user change it? | Watch honors it? |
+|---|---|---|
+| `dailyStepGoal` | yes | no — watch uses default `10_000` |
+| `endOfDayHour` | yes | no — watch uses default `21` |
+| `activeHoursStart` | yes | no — watch uses default `7` |
+| `activeHoursEnd` | yes | no — watch uses default `22` |
+| `contextAwareEnabled` | yes | no — watch uses default `false` |
+| `behindPaceCheckHour` | not exposed in phone UI | watch uses default `12` |
+| `inactivityThreshold` | yes | not consumed on watch at all (`EscalationManager.kt:57,67` reads a hardcoded `EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT`) |
+
+The root architectural problem is *schema drift*: `SettingsRepository` (phone, 8 fields) and `WatchSettingsCache` (watch, 6 fields) evolved independently with no shared contract.
+
+## Solution overview
+
+Introduce a new Wear Data Layer path `/settings` carrying typed primitive keys in a `DataMap`. A single `SettingsSnapshot` data class in `:shared/sync/` is the source of truth for the field set; its `toDataMap`/`fromDataMap` pair is the source of truth for the wire encoding. A hoisted `:shared/sync/SettingsDefaults` is the source of truth for default values used by both modules.
+
+Sync runs continuously while the phone app's process is alive (auto-push on change, debounced 500ms) and once on every phone-app foreground (full snapshot via `syncNow()` from `MainActivity.onResume`).
+
+### Why DataMap-native (vs. `|`-delimited string or JSON)
+
+- Zero serialization code; `DataMap` carries typed primitives natively.
+- Adding a field is one `putInt` on phone + one `getInt` on watch.
+- DataClient automatically dedupes by *bytes* — identical re-sends are no-ops.
+- Idiomatic for small fixed-shape payloads. We use `|`-delimited only for `Message` because messages are a list of complex objects DataMap can't hold natively.
+
+### Why shared `SettingsSnapshot` (vs. private to the syncer)
+
+- *Compile-time* schema-drift protection — adding a field to the data class breaks both modules (writer + reader) until both handle it. That's the structural fix for the root cause of #23.
+- One pure-function round-trip unit test catches key-name typos before runtime.
+- Mirrors `MessageSerializer`'s placement in `:shared`.
+
+### Why no timestamp in the payload
+
+DataClient dedupes by content bytes. Including a per-send timestamp would make every send a unique payload and fire `onDataChanged` even when no setting changed. Settings have no "stale" semantics on the watch — the latest snapshot is always authoritative — so omitting timestamp is the right call. This is a deliberate divergence from `/messages` (which carries a timestamp for sync-recency UI).
+
+## Architecture
+
+```
+                  PHONE                                  WATCH
+   ┌─────────────────────────────────────┐    ┌──────────────────────────────┐
+   │ SettingsRepository (DataStore Flows)│    │  WatchSettingsCache          │
+   │  — 7 watch-relevant Flows           │    │   (SharedPreferences)        │
+   └─────────────────┬───────────────────┘    └──────────────▲───────────────┘
+                     │ combine(...)                          │
+                     ▼                                       │
+   ┌─────────────────────────────────────┐                   │
+   │ PhoneSettingsSyncer                 │                   │
+   │  — launched once from               │                   │
+   │    MeatsackMobileApp.onCreate()     │                   │
+   │  — collects combined Flow,          │                   │
+   │    debounce(500ms),                 │                   │
+   │    distinctUntilChanged(),          │                   │
+   │    retryWhen(...),                  │                   │
+   │    writeSnapshot(snap)              │                   │
+   │  — exposes syncNow() called from    │                   │
+   │    MainActivity.onResume()          │                   │
+   └─────────────────┬───────────────────┘                   │
+                     │ DataClient                            │
+                     ▼                                       │
+   ┌─────────────────────────────────────┐    ┌──────────────┴───────────────┐
+   │ PutDataMapRequest(SettingsKeys.PATH)│───▶│ WatchSettingsReceiver        │
+   │   putInt(KEY_DAILY_STEP_GOAL, ...)  │    │  (WearableListenerService)   │
+   │   putInt(KEY_END_OF_DAY_HOUR, ...)  │    │   — onDataChanged filters     │
+   │   ...                               │    │     SettingsKeys.PATH         │
+   │                                     │    │   — SettingsSnapshot.from     │
+   │                                     │    │     DataMap(dm) → apply       │
+   │                                     │    │     field-by-field to cache   │
+   └─────────────────────────────────────┘    └──────────────────────────────┘
+```
+
+## Decisions
+
+### Trigger model — auto-push on change + on-resume full snapshot
+
+- `PhoneSettingsSyncer` is constructed in `MeatsackMobileApp.onCreate()` and `start(applicationScope)` is called there too. Hosting in `Application` (not `MainActivity`) means it runs whether or not the user has the app open — important because users edit settings in one session and may not relaunch before the next inactivity event.
+- `combine(...)` over the 7 watch-relevant `SettingsRepository` Flows produces a `SettingsSnapshot` each time any field changes. `debounce(500.milliseconds)` collapses slider drags into a single trailing write. `distinctUntilChanged()` suppresses redundant emissions.
+- `MainActivity.onResume()` calls `lifecycleScope.launch { syncer.syncNow() }`. `syncNow()` reads `.first()` of each Flow, builds a snapshot, and writes — same code path as the auto-push collector. DataClient dedupes if nothing changed.
+- The two paths cannot race: both call the same idempotent `writeSnapshot`; the worst case is two back-to-back writes where the second is a no-op.
+
+### Scope — 7 watch-relevant settings, aligned schema
+
+The sync payload covers 7 settings: the existing 6 watch fields (`contextAwareEnabled`, `activeHoursStart`, `activeHoursEnd`, `dailyStepGoal`, `endOfDayHour`, `behindPaceCheckHour`) plus `inactivityThreshold` (added to the watch and wired through `EscalationManager`).
+
+In addition to syncing, this PR closes two pre-existing schema-drift bugs:
+
+- **Add `behindPaceCheckHour` to phone:** new field on `SettingsRepository` + slider (0..23) on `SettingsScreen`. Currently watch-only with a hardcoded default.
+- **Wire `inactivityThreshold` through to consumption:** `WatchSettingsCache` gains the field; `EscalationManager.kt:57,67` is rewired to read it instead of the hardcoded `EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT`. The constructor takes a `thresholdProvider: () -> Int` to minimize Android coupling in tests.
+
+Out of scope (file separate follow-ups if not already tracked):
+
+- `quietHoursStart` / `quietHoursEnd` — phone exposes these but no consumer on the watch reads them; they're effectively phone-only state. Needs a separate feature discussion: do they suppress insults on the watch, or just shape the AI prompt? Track as a new issue.
+- Surface validator exceptions to UI (issue #21).
+- Worker silent-failure hardening (issue #24).
+
+### Wire format — DataMap native typed keys, no timestamp
+
+```kotlin
+// shared/src/main/java/com/meatsack/shared/sync/SettingsKeys.kt
+object SettingsKeys {
+    const val PATH = "/settings"
+    const val KEY_DAILY_STEP_GOAL = "daily_step_goal"
+    const val KEY_INACTIVITY_THRESHOLD = "inactivity_threshold_min"
+    const val KEY_ACTIVE_HOURS_START = "active_hours_start"
+    const val KEY_ACTIVE_HOURS_END = "active_hours_end"
+    const val KEY_CONTEXT_AWARE_ENABLED = "context_aware_enabled"
+    const val KEY_END_OF_DAY_HOUR = "end_of_day_hour"
+    const val KEY_BEHIND_PACE_CHECK_HOUR = "behind_pace_check_hour"
+    // intentionally no KEY_TIMESTAMP — see "Why no timestamp"
+}
+```
+
+### Defaults — hoisted to `:shared/sync/SettingsDefaults.kt`
+
+```kotlin
+// shared/src/main/java/com/meatsack/shared/sync/SettingsDefaults.kt
+object SettingsDefaults {
+    const val DAILY_STEP_GOAL = 10_000
+    const val INACTIVITY_THRESHOLD_MIN = 30
+    const val ACTIVE_HOURS_START = 7
+    const val ACTIVE_HOURS_END = 22
+    const val CONTEXT_AWARE_ENABLED = false
+    const val END_OF_DAY_HOUR = 21
+    const val BEHIND_PACE_CHECK_HOUR = 12
+}
+```
+
+Phone's `mobile/.../data/SettingsDefaults` is kept but trimmed to hold only `QUIET_HOURS_START` and `QUIET_HOURS_END` (phone-only fields). All other constants move to `:shared/sync/SettingsDefaults`. `SettingsRepository` imports from both. `WatchSettingsCache`'s hardcoded literal defaults are replaced with references to the shared constants. Plus a new `BEHIND_PACE_CHECK_HOUR = 12` constant lands in `:shared/sync/SettingsDefaults` to back the new phone-side Flow.
+
+## Components
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `shared/src/main/java/com/meatsack/shared/sync/SettingsKeys.kt` | DataMap path + key constants (see "Wire format"). |
+| `shared/src/main/java/com/meatsack/shared/sync/SettingsDefaults.kt` | Default values used by phone and watch (see "Defaults"). |
+| `shared/src/main/java/com/meatsack/shared/sync/SettingsSnapshot.kt` | `data class SettingsSnapshot(dailyStepGoal: Int, inactivityThreshold: Int, activeHoursStart: Int, activeHoursEnd: Int, contextAwareEnabled: Boolean, endOfDayHour: Int, behindPaceCheckHour: Int)`. Companion `defaults: SettingsSnapshot` built from `SettingsDefaults`. Companion `fromDataMap(dm: DataMap): SettingsSnapshot` reads each key with the matching default and applies `coerceIn(0..23)` to hour fields. Instance method `toDataMap(dm: DataMap)` writes each key. |
+| `mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt` | See "Trigger model". Constructor `(context, repo, dataClient = Wearable.getDataClient(context))` for test injection. |
+| `wear/src/main/java/com/meatsack/motivator/sync/WatchSettingsReceiver.kt` | `WearableListenerService`. `onDataChanged` filters `SettingsKeys.PATH`, calls `SettingsSnapshot.fromDataMap`, delegates to an `internal fun applySnapshot(snap, cache)` — the apply function is the unit-tested seam. |
+| `shared/src/test/java/com/meatsack/shared/sync/SettingsSnapshotTest.kt` | Round-trip, defaults, coerceIn. |
+| `mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt` | `syncNow` with fake DataClient; debounce + distinctUntilChanged via `kotlinx-coroutines-test`. |
+| `wear/src/test/java/com/meatsack/motivator/sync/WatchSettingsReceiverTest.kt` | Pure-JVM test of `applySnapshot` against a fake cache. |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `mobile/.../data/SettingsRepository.kt` | Add `behindPaceCheckHour: Flow<Int>` + `setBehindPaceCheckHour(hour: Int)` with `validateHour`. |
+| `mobile/.../data/SettingsDefaults.kt` | Trim to only `QUIET_HOURS_START` and `QUIET_HOURS_END`. Other 6 constants move to `:shared/sync/SettingsDefaults` (with a new `BEHIND_PACE_CHECK_HOUR` added there). Update `SettingsRepository`, `SettingsViewModel`, and `SettingsScreen` imports to source the shared defaults from `:shared`. |
+| `mobile/.../ui/settings/SettingsScreen.kt` | Add 0..23 slider for `behindPaceCheckHour`. |
+| `mobile/.../ui/settings/SettingsViewModel.kt` | Expose `behindPaceCheckHour` + setter. |
+| `mobile/.../MeatsackMobileApp.kt` | Construct `PhoneSettingsSyncer`; call `.start(applicationScope)` in `onCreate`. |
+| `mobile/.../MainActivity.kt` | In `onResume`, `lifecycleScope.launch { syncer.syncNow() }`. |
+| `wear/.../settings/WatchSettingsCache.kt` | Add `inactivityThreshold` field. Replace hardcoded literal defaults with `SettingsDefaults` references. |
+| `wear/.../escalation/EscalationManager.kt` | Add constructor parameter `thresholdProvider: () -> Int = { SettingsDefaults.INACTIVITY_THRESHOLD_MIN }`. Replace `EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT` reads with `thresholdProvider()`. |
+| `wear/.../MeatsackWearService.kt` | Pass `{ watchSettingsCache.inactivityThreshold }` into `EscalationManager`. |
+| `wear/src/main/AndroidManifest.xml` | Register `WatchSettingsReceiver` with `<intent-filter>` matching `SettingsKeys.PATH`. |
+| `wear/src/test/.../escalation/EscalationManagerTest.kt` | Pass `{ 30 }` (or test-specific value) into the new constructor parameter. |
+
+## Data flow
+
+### Steady state — user changes a slider
+
+1. User drags `Daily step goal` from 10000 → 12000 in `SettingsScreen`.
+2. `SettingsViewModel.setDailyStepGoal(12000)` → `SettingsRepository.setDailyStepGoal(12000)` writes to DataStore.
+3. The `dailyStepGoal: Flow<Int>` emits 12000.
+4. `PhoneSettingsSyncer`'s `combine(...)` re-emits a `SettingsSnapshot`. `debounce(500.ms)` waits for quiescence (so slider drags collapse).
+5. `distinctUntilChanged()` passes through (different from prior). `writeSnapshot(snap)` builds the `PutDataMapRequest(SettingsKeys.PATH)` with 7 typed keys via `snap.toDataMap(dm)`, calls `setUrgent()`, `await()`.
+6. Wear Data Layer delivers to watch.
+7. `WatchSettingsReceiver.onDataChanged` fires → `SettingsSnapshot.fromDataMap(dm)` → `applySnapshot(snap, cache)` writes each field.
+8. Next time `EscalationManager.thresholdProvider()` or `BehindPaceWorker` reads via `cache`, it returns the new value.
+
+### Phone app launch — on-resume snapshot
+
+1. User opens `MainActivity`. `onResume` launches `syncer.syncNow()`.
+2. `syncNow()` reads `.first()` of each Flow, builds a snapshot, calls `writeSnapshot`.
+3. DataClient dedupes by content: if nothing changed since last sync, the watch sees no `onDataChanged` event. Free belt-and-suspenders for any change that landed while the phone process was killed.
+
+### Watch boots before any sync ever
+
+1. `MeatsackWearService` starts. `WatchSettingsCache(context)` instantiates.
+2. `prefs.getInt(KEY_DAILY_STEP_GOAL, SettingsDefaults.DAILY_STEP_GOAL)` returns the shared default. Watch behavior is unchanged from today — defaults rule until first sync.
+3. As soon as the phone runs `MainActivity.onResume` (or auto-pushes after any edit), the cache is populated.
+
+## Error handling
+
+| Scenario | Handling |
+|---|---|
+| `SettingsRepository` Flow throws (DataStore corruption) | Phone syncer: `.catch { e -> Log.e(TAG, "settings flow failure", e); emit(SettingsSnapshot.defaults) }` on the combined flow — don't kill the collector. |
+| `DataClient.putDataItem` fails / watch disconnected | `try/catch (CancellationException) { throw }` + `catch (Exception) { Log.e }`. Mirror `PhoneSyncSender.kt:62-67`. DataClient queues locally and delivers on reconnect. |
+| Collector pipeline dies after exception | Bounded `.retryWhen { cause, attempt -> attempt < 3 && delay((1 shl attempt).seconds).let { true } }` — three attempts with exponential backoff, then leave a sticky log. No infinite restart (corruption should surface, not be silently masked). |
+| Receiver throws during `onDataChanged` | Same try/catch shape as `WatchSyncReceiver.kt:53-59`. |
+| Missing key on watch (forward-compat: phone older than watch) | `dm.getInt(KEY, SettingsDefaults.X)` returns shared default. No crash. |
+| Unknown extra keys on watch (backward-compat: phone newer than watch) | Ignored by `dm.getInt` — only known keys are read. Safe. |
+| Out-of-range hour on the wire | `SettingsSnapshot.fromDataMap` applies `coerceIn(0, 23)` to hour fields. Phone's `validateHour` should already prevent this; defense in depth (also partially addresses issue #25). |
+| Watch boots before any sync ever | Already handled today; behavior unchanged after the shared-defaults move. |
+| Validation failure on phone (e.g., `setBehindPaceCheckHour(99)`) | Existing setters throw `IllegalArgumentException`; ViewModel currently swallows. Out of scope (tracked in #21). |
+
+Deliberately *not* added: DataItem quota throttling, network failures, "watch not paired" detection. DataClient handles all of these silently and asynchronously. Adding code that suppresses these exceptions invites the same silent-failure anti-pattern issue #24 is fighting.
+
+## Testing strategy
+
+| Surface | Test type | What it asserts |
+|---|---|---|
+| `SettingsSnapshot.toDataMap` / `fromDataMap` | Pure-JVM if DataMap permits; else Robolectric in `:shared/src/test`. | Round-trip equality; missing keys → defaults; out-of-range hours clamped via `coerceIn(0..23)`; assertions that defaults match `SettingsDefaults` (catches drift). |
+| `PhoneSettingsSyncer.syncNow` | Unit + fake DataClient (constructor-injected) | Builds `PutDataMapRequest` with correct path + 7 keys + correct values; rethrows `CancellationException`; logs+swallows other exceptions. |
+| `PhoneSettingsSyncer.start` debouncing | Unit + `kotlinx-coroutines-test` + Turbine | 3 rapid Flow emissions within 500ms → 1 `writeSnapshot` call; identical consecutive snapshots → 1 call only (distinctUntilChanged); `.retryWhen` restarts after thrown exception up to 3 times then gives up. |
+| Receiver apply logic | Pure-JVM | Extract `internal fun applySnapshot(snap, sink)`. `WatchSettingsCache` implements a small `SettingsSink` interface (or test uses a Map-backed fake). Verify every field gets written. |
+| `WatchSettingsCache.inactivityThreshold` | Robolectric for SharedPreferences | Default returns 30 (from `SettingsDefaults`); setter persists. |
+| `EscalationManager` post-rewire | Unit | Constructor takes `thresholdProvider: () -> Int`. Production passes `{ cache.inactivityThreshold }`; tests pass `{ 30 }`. Update existing test fixtures. |
+| `SettingsRepository.behindPaceCheckHour` | Existing test infra | New Flow emits default 12; setter throws on invalid hour; setter persists valid value. |
+| End-to-end on paired emulators | Manual | Documented in spec — change phone slider, observe watch logcat for `WatchSettingsReceiver` apply log within ~2 seconds. |
+
+**DataMap unit-testability:** historical note — `com.google.android.gms.wearable.DataMap` is part of GMS but is a value class with no Android-platform dependencies in modern Play Services releases. The implementation plan should record "verify pure-JVM at write-time; if it requires Android classes, add Robolectric to `:shared/src/test`."
+
+**Why no test for `onResume → syncNow` wiring:** that call is one line in `MainActivity.onResume`, and Activity lifecycle tests are heavyweight. The integration is verified by the manual end-to-end smoke; spend test budget where the logic lives, not where it's plumbed.
+
+## Manual end-to-end checklist
+
+To verify on paired emulators (after `./gradlew :mobile:installDebug` + `./gradlew :wear:installDebug`):
+
+1. Grant `ACTIVITY_RECOGNITION` on the watch (`adb -s emulator-5556 shell pm grant com.meatsack.motivator android.permission.ACTIVITY_RECOGNITION`).
+2. Launch phone app. Confirm logcat shows `PhoneSettingsSyncer: syncNow OK (...)` shortly after.
+3. Open Settings tab on phone. Drag `Daily step goal` slider to a new value.
+4. Within ~2 seconds, watch logcat should show `WatchSettingsReceiver: applied snapshot ...` with the new value.
+5. Open the watch app (or trigger BehindPaceWorker manually via `adb shell` for a fast check) and verify the new goal is in effect.
+6. Force-stop the phone app. Edit a watch-relevant setting via DataStore (or skip — covered by step 3). Relaunch — `onResume` should fire one `syncNow` even if nothing changed (DataClient dedupes, so the watch shouldn't see an event).
+7. Pull the phone-watch Bluetooth pairing offline, change a setting, restore — DataClient should deliver the queued DataItem.
+
+## Open follow-ups (out of scope for this PR)
+
+- **Issue #21** — surface setter validation exceptions to UI.
+- **Issue #24** — harden worker bodies against silent DAO/notifier exceptions.
+- **Issue #25** — `WatchSettingsCache.coerceIn(0..23)` defense at read time (partially covered here by `fromDataMap`'s coerce, but the cache itself still trusts its stored values).
+- **New issue (file separately):** decide whether `quietHoursStart` / `quietHoursEnd` should reach the watch and what they should mean there (suppress insults? shape AI prompt? both?).
+- **Issue #27** — `TriggerScheduler.millisUntilNextHour` companion + tests.
+
+## Spec acceptance criteria
+
+- Phone slider edits propagate to watch within ~2 seconds when paired.
+- Watch boot without any prior sync still works (defaults).
+- No new behavior regressions in `EscalationManager` after the threshold-provider rewire.
+- `./gradlew build` + `:wear:testDebugUnitTest` + `:shared:testDebugUnitTest` + `:mobile:testDebugUnitTest` all pass.
+- New tests cover `SettingsSnapshot` round-trip, `PhoneSettingsSyncer` debounce/dedup, and `applySnapshot` correctness.

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -42,6 +42,9 @@ android {
     buildFeatures {
         compose = true
     }
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
     // anthropic-java pulls in Apache HttpClient5 transitively; multiple
     // jars contribute META-INF resource files with the same path which the
     // Android packager refuses to merge. Drop them from the APK.
@@ -85,6 +88,7 @@ dependencies {
     implementation(libs.androidx.security.crypto)
     debugImplementation(libs.androidx.compose.ui.tooling)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/MainActivity.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/MainActivity.kt
@@ -1,17 +1,37 @@
 package com.meatsack.motivator.mobile
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
+import androidx.lifecycle.lifecycleScope
 import com.meatsack.motivator.mobile.ui.navigation.MeatsackNavGraph
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
+
+    companion object {
+        private const val TAG = "MainActivity"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             MaterialTheme {
                 MeatsackNavGraph()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val app = applicationContext as MeatsackMobileApp
+        lifecycleScope.launch {
+            try {
+                app.settingsSyncer.syncNow()
+            } catch (t: Throwable) {
+                Log.w(TAG, "onResume syncNow failed", t)
             }
         }
     }

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/MainActivity.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.lifecycle.lifecycleScope
+import com.meatsack.motivator.mobile.sync.SettingsSyncResult
 import com.meatsack.motivator.mobile.ui.navigation.MeatsackNavGraph
 import kotlinx.coroutines.launch
 
@@ -29,9 +30,15 @@ class MainActivity : ComponentActivity() {
         val app = applicationContext as MeatsackMobileApp
         lifecycleScope.launch {
             try {
-                app.settingsSyncer.syncNow()
+                when (val result = app.settingsSyncer.syncNow()) {
+                    SettingsSyncResult.Success -> Unit
+                    is SettingsSyncResult.Failed ->
+                        Log.e(TAG, "onResume syncNow failed", result.error)
+                }
+            } catch (ce: kotlinx.coroutines.CancellationException) {
+                throw ce
             } catch (t: Throwable) {
-                Log.w(TAG, "onResume syncNow failed", t)
+                Log.e(TAG, "onResume syncNow unexpected throw", t)
             }
         }
     }

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/MeatsackMobileApp.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/MeatsackMobileApp.kt
@@ -2,6 +2,10 @@ package com.meatsack.motivator.mobile
 
 import android.app.Application
 import android.util.Log
+import com.meatsack.motivator.mobile.data.SettingsRepository
+import com.meatsack.motivator.mobile.sync.PhoneSettingsSyncer
+import com.meatsack.motivator.mobile.sync.RepositorySettingsSource
+import com.meatsack.motivator.mobile.sync.WearableSettingsSink
 import com.meatsack.shared.data.SeedData
 import com.meatsack.shared.db.AppDatabase
 import kotlinx.coroutines.CoroutineScope
@@ -17,9 +21,19 @@ class MeatsackMobileApp : Application() {
      */
     val applicationScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    lateinit var settingsSyncer: PhoneSettingsSyncer
+        private set
+
     override fun onCreate() {
         super.onCreate()
         seedDatabaseIfEmpty()
+        val repo = SettingsRepository(this)
+        settingsSyncer = PhoneSettingsSyncer(
+            settings = RepositorySettingsSource(repo),
+            sink = WearableSettingsSink(this),
+        )
+        settingsSyncer.start(applicationScope)
+        Log.d(TAG, "PhoneSettingsSyncer started")
     }
 
     private fun seedDatabaseIfEmpty() {

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsDefaults.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsDefaults.kt
@@ -1,8 +1,8 @@
 package com.meatsack.motivator.mobile.data
 
 /**
- * Phone-only setting defaults. The 7 watch-shared defaults moved to
- * com.meatsack.shared.sync.SettingsDefaults in the settings-sync work.
+ * Phone-only setting defaults. Watch-shared defaults live in
+ * com.meatsack.shared.sync.SettingsDefaults so both modules read the same values.
  */
 object SettingsDefaults {
     const val QUIET_HOURS_START = 22

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsDefaults.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsDefaults.kt
@@ -1,12 +1,10 @@
 package com.meatsack.motivator.mobile.data
 
+/**
+ * Phone-only setting defaults. The 7 watch-shared defaults moved to
+ * com.meatsack.shared.sync.SettingsDefaults in the settings-sync work.
+ */
 object SettingsDefaults {
-    const val DAILY_STEP_GOAL = 10_000
-    const val INACTIVITY_THRESHOLD_MIN = 30
-    const val ACTIVE_HOURS_START = 7
-    const val ACTIVE_HOURS_END = 22
     const val QUIET_HOURS_START = 22
     const val QUIET_HOURS_END = 7
-    const val CONTEXT_AWARE_ENABLED = false
-    const val END_OF_DAY_HOUR = 21 // default 9pm
 }

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import com.meatsack.shared.sync.SettingsDefaults as SharedDefaults
 
 private val Context.dataStore by preferencesDataStore("meatsack_settings")
 
@@ -32,16 +33,16 @@ class SettingsRepository(private val context: Context) {
     }
 
     val dailyStepGoal: Flow<Int> = context.dataStore.data.map {
-        it[DAILY_STEP_GOAL] ?: SettingsDefaults.DAILY_STEP_GOAL
+        it[DAILY_STEP_GOAL] ?: SharedDefaults.DAILY_STEP_GOAL
     }
     val inactivityThreshold: Flow<Int> = context.dataStore.data.map {
-        it[INACTIVITY_THRESHOLD] ?: SettingsDefaults.INACTIVITY_THRESHOLD_MIN
+        it[INACTIVITY_THRESHOLD] ?: SharedDefaults.INACTIVITY_THRESHOLD_MIN
     }
     val activeHoursStart: Flow<Int> = context.dataStore.data.map {
-        it[ACTIVE_HOURS_START] ?: SettingsDefaults.ACTIVE_HOURS_START
+        it[ACTIVE_HOURS_START] ?: SharedDefaults.ACTIVE_HOURS_START
     }
     val activeHoursEnd: Flow<Int> = context.dataStore.data.map {
-        it[ACTIVE_HOURS_END] ?: SettingsDefaults.ACTIVE_HOURS_END
+        it[ACTIVE_HOURS_END] ?: SharedDefaults.ACTIVE_HOURS_END
     }
     val quietHoursStart: Flow<Int> = context.dataStore.data.map {
         it[QUIET_HOURS_START] ?: SettingsDefaults.QUIET_HOURS_START
@@ -50,10 +51,10 @@ class SettingsRepository(private val context: Context) {
         it[QUIET_HOURS_END] ?: SettingsDefaults.QUIET_HOURS_END
     }
     val contextAwareEnabled: Flow<Boolean> = context.dataStore.data.map {
-        it[CONTEXT_AWARE_ENABLED] ?: SettingsDefaults.CONTEXT_AWARE_ENABLED
+        it[CONTEXT_AWARE_ENABLED] ?: SharedDefaults.CONTEXT_AWARE_ENABLED
     }
     val endOfDayHour: Flow<Int> = context.dataStore.data.map {
-        it[END_OF_DAY_HOUR] ?: SettingsDefaults.END_OF_DAY_HOUR
+        it[END_OF_DAY_HOUR] ?: SharedDefaults.END_OF_DAY_HOUR
     }
 
     suspend fun setDailyStepGoal(goal: Int) {

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/data/SettingsRepository.kt
@@ -22,6 +22,7 @@ class SettingsRepository(private val context: Context) {
         val QUIET_HOURS_END = intPreferencesKey("quiet_hours_end")
         val CONTEXT_AWARE_ENABLED = booleanPreferencesKey("context_aware_enabled")
         val END_OF_DAY_HOUR = intPreferencesKey("end_of_day_hour")
+        val BEHIND_PACE_CHECK_HOUR = intPreferencesKey("behind_pace_check_hour")
 
         internal fun validateHour(name: String, hour: Int) {
             require(hour in 0..23) { "$name must be in 0..23; was $hour" }
@@ -55,6 +56,9 @@ class SettingsRepository(private val context: Context) {
     }
     val endOfDayHour: Flow<Int> = context.dataStore.data.map {
         it[END_OF_DAY_HOUR] ?: SharedDefaults.END_OF_DAY_HOUR
+    }
+    val behindPaceCheckHour: Flow<Int> = context.dataStore.data.map {
+        it[BEHIND_PACE_CHECK_HOUR] ?: SharedDefaults.BEHIND_PACE_CHECK_HOUR
     }
 
     suspend fun setDailyStepGoal(goal: Int) {
@@ -92,5 +96,10 @@ class SettingsRepository(private val context: Context) {
     suspend fun setEndOfDayHour(hour: Int) {
         validateHour("End of day hour", hour)
         context.dataStore.edit { it[END_OF_DAY_HOUR] = hour }
+    }
+
+    suspend fun setBehindPaceCheckHour(hour: Int) {
+        validateHour("Behind pace check hour", hour)
+        context.dataStore.edit { it[BEHIND_PACE_CHECK_HOUR] = hour }
     }
 }

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt
@@ -1,0 +1,53 @@
+package com.meatsack.motivator.mobile.sync
+
+import android.util.Log
+import com.google.android.gms.wearable.DataMap
+import com.meatsack.shared.sync.SettingsKeys
+import com.meatsack.shared.sync.SettingsSnapshot
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Source of SettingsSnapshot updates. Production wires this to combine() over
+ * SettingsRepository flows; tests use an in-memory MutableStateFlow.
+ */
+interface SettingsSource {
+    val snapshots: Flow<SettingsSnapshot>
+    suspend fun current(): SettingsSnapshot
+}
+
+/**
+ * Single-method abstraction over the Wear DataClient. Production wraps
+ * Wearable.getDataClient(context).putDataItem(...); tests fake it.
+ */
+interface SettingsSink {
+    suspend fun put(path: String, dataMap: DataMap)
+}
+
+class PhoneSettingsSyncer(
+    private val settings: SettingsSource,
+    private val sink: SettingsSink,
+) {
+
+    companion object {
+        private const val TAG = "PhoneSettingsSyncer"
+    }
+
+    suspend fun syncNow() {
+        val snap = settings.current()
+        writeSnapshot(snap)
+    }
+
+    private suspend fun writeSnapshot(snap: SettingsSnapshot) {
+        try {
+            val dm = DataMap()
+            snap.toDataMap(dm)
+            sink.put(SettingsKeys.PATH, dm)
+            Log.d(TAG, "Synced settings: $snap")
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (e: Exception) {
+            Log.e(TAG, "Settings sync failed", e)
+        }
+    }
+}

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt
@@ -1,7 +1,11 @@
 package com.meatsack.motivator.mobile.sync
 
+import android.content.Context
 import android.util.Log
 import com.google.android.gms.wearable.DataMap
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import com.meatsack.motivator.mobile.data.SettingsRepository
 import com.meatsack.shared.sync.SettingsKeys
 import com.meatsack.shared.sync.SettingsSnapshot
 import kotlinx.coroutines.CancellationException
@@ -12,8 +16,10 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -80,5 +86,52 @@ class PhoneSettingsSyncer(
         } catch (e: Exception) {
             Log.e(TAG, "Settings sync failed", e)
         }
+    }
+}
+
+/**
+ * Production SettingsSource backed by SettingsRepository. Combines the 7
+ * watch-relevant Flows into a single SettingsSnapshot.
+ */
+class RepositorySettingsSource(private val repo: SettingsRepository) : SettingsSource {
+    override val snapshots: Flow<SettingsSnapshot> = kotlinx.coroutines.flow.combine(
+        repo.dailyStepGoal,
+        repo.inactivityThreshold,
+        repo.activeHoursStart,
+        repo.activeHoursEnd,
+        repo.contextAwareEnabled,
+        repo.endOfDayHour,
+        repo.behindPaceCheckHour,
+    ) { values ->
+        SettingsSnapshot(
+            dailyStepGoal = values[0] as Int,
+            inactivityThreshold = values[1] as Int,
+            activeHoursStart = values[2] as Int,
+            activeHoursEnd = values[3] as Int,
+            contextAwareEnabled = values[4] as Boolean,
+            endOfDayHour = values[5] as Int,
+            behindPaceCheckHour = values[6] as Int,
+        )
+    }
+
+    override suspend fun current(): SettingsSnapshot =
+        SettingsSnapshot(
+            dailyStepGoal = repo.dailyStepGoal.first(),
+            inactivityThreshold = repo.inactivityThreshold.first(),
+            activeHoursStart = repo.activeHoursStart.first(),
+            activeHoursEnd = repo.activeHoursEnd.first(),
+            contextAwareEnabled = repo.contextAwareEnabled.first(),
+            endOfDayHour = repo.endOfDayHour.first(),
+            behindPaceCheckHour = repo.behindPaceCheckHour.first(),
+        )
+}
+
+/** Production sink that writes via Wearable.getDataClient. */
+class WearableSettingsSink(private val context: Context) : SettingsSink {
+    override suspend fun put(path: String, dataMap: DataMap) {
+        val req = PutDataMapRequest.create(path).apply {
+            this.dataMap.putAll(dataMap)
+        }.asPutDataRequest().setUrgent()
+        Wearable.getDataClient(context).putDataItem(req).await()
     }
 }

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt
@@ -24,6 +24,16 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
+ * Outcome of a single settings sync attempt. Mirrors `PhoneSyncSender.SyncResult` —
+ * distinguishing Success from Failed lets `MainActivity.onResume` log failures at
+ * ERROR rather than silently swallowing them at WARN.
+ */
+sealed class SettingsSyncResult {
+    data object Success : SettingsSyncResult()
+    data class Failed(val error: Throwable) : SettingsSyncResult()
+}
+
+/**
  * Source of SettingsSnapshot updates. Production wires this to combine() over
  * SettingsRepository flows; tests use an in-memory MutableStateFlow.
  */
@@ -71,21 +81,19 @@ class PhoneSettingsSyncer(
         }
     }
 
-    suspend fun syncNow() {
-        writeSnapshot(settings.current())
-    }
+    suspend fun syncNow(): SettingsSyncResult = writeSnapshot(settings.current())
 
-    private suspend fun writeSnapshot(snap: SettingsSnapshot) {
-        try {
-            val dm = DataMap()
-            snap.toDataMap(dm)
-            sink.put(SettingsKeys.PATH, dm)
-            Log.d(TAG, "Synced settings: $snap")
-        } catch (ce: CancellationException) {
-            throw ce
-        } catch (e: Exception) {
-            Log.e(TAG, "Settings sync failed", e)
-        }
+    private suspend fun writeSnapshot(snap: SettingsSnapshot): SettingsSyncResult = try {
+        val dm = DataMap()
+        snap.toDataMap(dm)
+        sink.put(SettingsKeys.PATH, dm)
+        Log.d(TAG, "Synced settings: $snap")
+        SettingsSyncResult.Success
+    } catch (ce: CancellationException) {
+        throw ce
+    } catch (e: Exception) {
+        Log.e(TAG, "Settings sync failed", e)
+        SettingsSyncResult.Failed(e)
     }
 }
 

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncer.kt
@@ -5,7 +5,17 @@ import com.google.android.gms.wearable.DataMap
 import com.meatsack.shared.sync.SettingsKeys
 import com.meatsack.shared.sync.SettingsSnapshot
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Source of SettingsSnapshot updates. Production wires this to combine() over
@@ -31,11 +41,32 @@ class PhoneSettingsSyncer(
 
     companion object {
         private const val TAG = "PhoneSettingsSyncer"
+        private const val MAX_RETRY_ATTEMPTS = 3
+    }
+
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
+    fun start(scope: CoroutineScope) {
+        scope.launch {
+            settings.snapshots
+                .debounce(500.milliseconds)
+                .distinctUntilChanged()
+                .retryWhen { cause, attempt ->
+                    if (attempt < MAX_RETRY_ATTEMPTS) {
+                        Log.w(TAG, "settings flow failure (attempt=$attempt), retrying", cause)
+                        delay(((1L shl attempt.toInt()).coerceAtMost(8)).seconds)
+                        true
+                    } else {
+                        Log.e(TAG, "settings flow gave up after $MAX_RETRY_ATTEMPTS retries", cause)
+                        false
+                    }
+                }
+                .catch { e -> Log.e(TAG, "settings flow terminated", e) }
+                .collect { snap -> writeSnapshot(snap) }
+        }
     }
 
     suspend fun syncNow() {
-        val snap = settings.current()
-        writeSnapshot(snap)
+        writeSnapshot(settings.current())
     }
 
     private suspend fun writeSnapshot(snap: SettingsSnapshot) {

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsScreen.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsScreen.kt
@@ -116,6 +116,24 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
         )
         Spacer(Modifier.height(16.dp))
 
+        val behindPaceHour by viewModel.behindPaceCheckHour.collectAsState()
+        Text(
+            "Behind-pace check hour: $behindPaceHour:00",
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Slider(
+            value = behindPaceHour.toFloat(),
+            onValueChange = { viewModel.updateBehindPaceCheckHour(it.toInt()) },
+            valueRange = 0f..23f,
+            steps = 22,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            "Time of day to check whether you're behind your step goal.",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Spacer(Modifier.height(16.dp))
+
         Spacer(Modifier.height(24.dp))
         Text("Anthropic API key", style = MaterialTheme.typography.titleMedium)
 

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt
@@ -70,6 +70,11 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         SharingStarted.WhileSubscribed(),
         SharedDefaults.END_OF_DAY_HOUR,
     )
+    val behindPaceCheckHour = repo.behindPaceCheckHour.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(),
+        SharedDefaults.BEHIND_PACE_CHECK_HOUR,
+    )
 
     fun updateStepGoal(goal: Int) = viewModelScope.launch { repo.setDailyStepGoal(goal) }
     fun updateInactivityThreshold(min: Int) =
@@ -81,6 +86,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun toggleContextAware(enabled: Boolean) =
         viewModelScope.launch { repo.setContextAwareEnabled(enabled) }
     fun updateEndOfDayHour(hour: Int) = viewModelScope.launch { repo.setEndOfDayHour(hour) }
+    fun updateBehindPaceCheckHour(hour: Int) =
+        viewModelScope.launch { repo.setBehindPaceCheckHour(hour) }
 
     fun saveApiKey(key: String) {
         if (key.isBlank()) apiKeyStore.clear() else apiKeyStore.save(key)

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.Calendar
+import com.meatsack.shared.sync.SettingsDefaults as SharedDefaults
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val repo = SettingsRepository(application)
@@ -32,22 +33,22 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     val dailyStepGoal = repo.dailyStepGoal.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(),
-        SettingsDefaults.DAILY_STEP_GOAL,
+        SharedDefaults.DAILY_STEP_GOAL,
     )
     val inactivityThreshold = repo.inactivityThreshold.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(),
-        SettingsDefaults.INACTIVITY_THRESHOLD_MIN,
+        SharedDefaults.INACTIVITY_THRESHOLD_MIN,
     )
     val activeHoursStart = repo.activeHoursStart.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(),
-        SettingsDefaults.ACTIVE_HOURS_START,
+        SharedDefaults.ACTIVE_HOURS_START,
     )
     val activeHoursEnd = repo.activeHoursEnd.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(),
-        SettingsDefaults.ACTIVE_HOURS_END,
+        SharedDefaults.ACTIVE_HOURS_END,
     )
     val quietHoursStart = repo.quietHoursStart.stateIn(
         viewModelScope,
@@ -62,12 +63,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     val contextAwareEnabled = repo.contextAwareEnabled.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(),
-        SettingsDefaults.CONTEXT_AWARE_ENABLED,
+        SharedDefaults.CONTEXT_AWARE_ENABLED,
     )
     val endOfDayHour = repo.endOfDayHour.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(),
-        SettingsDefaults.END_OF_DAY_HOUR,
+        SharedDefaults.END_OF_DAY_HOUR,
     )
 
     fun updateStepGoal(goal: Int) = viewModelScope.launch { repo.setDailyStepGoal(goal) }

--- a/mobile/src/test/java/com/meatsack/motivator/mobile/data/SettingsRepositoryTest.kt
+++ b/mobile/src/test/java/com/meatsack/motivator/mobile/data/SettingsRepositoryTest.kt
@@ -76,4 +76,15 @@ class SettingsRepositoryTest {
             SettingsRepository.validatePositive("test", -500)
         }
     }
+
+    @Test
+    fun validateHour_rejectsTooLarge_forBehindPaceCheck() {
+        val e = assertThrows(IllegalArgumentException::class.java) {
+            SettingsRepository.validateHour("Behind pace check hour", 24)
+        }
+        assertTrue(
+            "Message should include field name; was: ${e.message}",
+            e.message?.contains("Behind pace check hour") == true,
+        )
+    }
 }

--- a/mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
+++ b/mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
@@ -45,11 +45,12 @@ class PhoneSettingsSyncerTest {
         val sink = FakeSink()
         val syncer = PhoneSettingsSyncer(FakeSettingsSource(custom), sink)
 
-        syncer.syncNow()
+        val result = syncer.syncNow()
 
         val dm = sink.lastDataMap
         assertNotNull("expected sink to receive a DataMap", dm)
         val parsed = SettingsSnapshot.fromDataMap(dm!!)
+        assertEquals(SettingsSyncResult.Success, result)
         assertEquals(custom, parsed)
         assertEquals(1, sink.callCount)
     }
@@ -71,8 +72,8 @@ class PhoneSettingsSyncerTest {
     fun syncNow_swallowsAndLogsOtherExceptions() = runTest {
         val sink = FakeSink().apply { failNextWith = RuntimeException("network down") }
         val syncer = PhoneSettingsSyncer(FakeSettingsSource(SettingsSnapshot.defaults), sink)
-        syncer.syncNow() // should not throw
-        // Nothing else to assert — no exception is the success criterion.
+        val result = syncer.syncNow()
+        assertTrue("expected Failed", result is SettingsSyncResult.Failed)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
+++ b/mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
@@ -3,7 +3,10 @@ package com.meatsack.motivator.mobile.sync
 import com.google.android.gms.wearable.DataMap
 import com.meatsack.shared.sync.SettingsKeys
 import com.meatsack.shared.sync.SettingsSnapshot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -70,5 +73,47 @@ class PhoneSettingsSyncerTest {
         val syncer = PhoneSettingsSyncer(FakeSettingsSource(SettingsSnapshot.defaults), sink)
         syncer.syncNow() // should not throw
         // Nothing else to assert — no exception is the success criterion.
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun start_debouncesRapidEmissionsToSingleWrite() = runTest {
+        val source = FakeSettingsSource(SettingsSnapshot.defaults)
+        val sink = FakeSink()
+        val syncer = PhoneSettingsSyncer(source, sink)
+
+        val job = launch { syncer.start(this) }
+
+        // Three rapid edits within the 500ms debounce window — should collapse to one write.
+        source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 11000)
+        advanceTimeBy(100)
+        source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 12000)
+        advanceTimeBy(100)
+        source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 13000)
+        advanceTimeBy(600) // > debounce window
+
+        assertEquals("expected only the trailing emission to be written", 1, sink.callCount)
+        val parsed = SettingsSnapshot.fromDataMap(sink.lastDataMap!!)
+        assertEquals(13000, parsed.dailyStepGoal)
+
+        job.cancel()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun start_distinctUntilChanged_suppressesIdenticalEmissions() = runTest {
+        val source = FakeSettingsSource(SettingsSnapshot.defaults)
+        val sink = FakeSink()
+        val syncer = PhoneSettingsSyncer(source, sink)
+
+        val job = launch { syncer.start(this) }
+
+        source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 11000)
+        advanceTimeBy(600)
+        source.snapshots.value = SettingsSnapshot.defaults.copy(dailyStepGoal = 11000) // identical
+        advanceTimeBy(600)
+
+        assertEquals(1, sink.callCount)
+        job.cancel()
     }
 }

--- a/mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
+++ b/mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
@@ -1,0 +1,73 @@
+package com.meatsack.motivator.mobile.sync
+
+import com.google.android.gms.wearable.DataMap
+import com.meatsack.shared.sync.SettingsKeys
+import com.meatsack.shared.sync.SettingsSnapshot
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class PhoneSettingsSyncerTest {
+
+    private class FakeSink : SettingsSink {
+        var lastDataMap: DataMap? = null
+        var callCount = 0
+        var failNextWith: Throwable? = null
+        override suspend fun put(path: String, dataMap: DataMap) {
+            callCount++
+            failNextWith?.let {
+                failNextWith = null
+                throw it
+            }
+            assertEquals(SettingsKeys.PATH, path)
+            lastDataMap = dataMap
+        }
+    }
+
+    private class FakeSettingsSource(initial: SettingsSnapshot) : SettingsSource {
+        override val snapshots = MutableStateFlow(initial)
+        override suspend fun current(): SettingsSnapshot = snapshots.value
+    }
+
+    @Test
+    fun syncNow_writesAllFieldsAtSettingsPath() = runTest {
+        val custom = SettingsSnapshot.defaults.copy(
+            dailyStepGoal = 12345,
+            inactivityThreshold = 45,
+            behindPaceCheckHour = 14,
+        )
+        val sink = FakeSink()
+        val syncer = PhoneSettingsSyncer(FakeSettingsSource(custom), sink)
+
+        syncer.syncNow()
+
+        val dm = sink.lastDataMap
+        assertNotNull("expected sink to receive a DataMap", dm)
+        val parsed = SettingsSnapshot.fromDataMap(dm!!)
+        assertEquals(custom, parsed)
+        assertEquals(1, sink.callCount)
+    }
+
+    @Test
+    fun syncNow_propagatesCancellation() = runTest {
+        val sink = FakeSink().apply { failNextWith = kotlinx.coroutines.CancellationException("test") }
+        val syncer = PhoneSettingsSyncer(FakeSettingsSource(SettingsSnapshot.defaults), sink)
+        var threw = false
+        try {
+            syncer.syncNow()
+        } catch (_: kotlinx.coroutines.CancellationException) {
+            threw = true
+        }
+        assert(threw) { "syncNow should rethrow CancellationException" }
+    }
+
+    @Test
+    fun syncNow_swallowsAndLogsOtherExceptions() = runTest {
+        val sink = FakeSink().apply { failNextWith = RuntimeException("network down") }
+        val syncer = PhoneSettingsSyncer(FakeSettingsSource(SettingsSnapshot.defaults), sink)
+        syncer.syncNow() // should not throw
+        // Nothing else to assert — no exception is the success criterion.
+    }
+}

--- a/mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
+++ b/mobile/src/test/java/com/meatsack/motivator/mobile/sync/PhoneSettingsSyncerTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PhoneSettingsSyncerTest {
@@ -60,7 +61,7 @@ class PhoneSettingsSyncerTest {
         } catch (_: kotlinx.coroutines.CancellationException) {
             threw = true
         }
-        assert(threw) { "syncNow should rethrow CancellationException" }
+        assertTrue("syncNow should rethrow CancellationException", threw)
     }
 
     @Test

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.play.services.wearable)
     api(libs.androidx.room.runtime)
     api(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)

--- a/shared/src/main/java/com/meatsack/shared/sync/SettingsDefaults.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/SettingsDefaults.kt
@@ -1,0 +1,16 @@
+package com.meatsack.shared.sync
+
+/**
+ * Default values for the 7 settings the watch consumes. Mirrored by phone
+ * (SettingsRepository fallbacks) and watch (WatchSettingsCache fallbacks).
+ * Single source of truth — adding a default here is the only place to change it.
+ */
+object SettingsDefaults {
+    const val DAILY_STEP_GOAL = 10_000
+    const val INACTIVITY_THRESHOLD_MIN = 30
+    const val ACTIVE_HOURS_START = 7
+    const val ACTIVE_HOURS_END = 22
+    const val CONTEXT_AWARE_ENABLED = false
+    const val END_OF_DAY_HOUR = 21 // 9pm
+    const val BEHIND_PACE_CHECK_HOUR = 12 // noon
+}

--- a/shared/src/main/java/com/meatsack/shared/sync/SettingsKeys.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/SettingsKeys.kt
@@ -1,0 +1,21 @@
+package com.meatsack.shared.sync
+
+/**
+ * Wire-level keys for the /settings DataItem channel. Single source of truth for
+ * both PhoneSettingsSyncer (writer) and WatchSettingsReceiver (reader). Adding
+ * a key here is the only edit needed before wiring it on each side.
+ *
+ * No KEY_TIMESTAMP: DataClient dedupes by content bytes, and settings have no
+ * "stale" semantics on the watch — including a timestamp would fire onDataChanged
+ * on every send even when nothing changed. Deliberate divergence from /messages.
+ */
+object SettingsKeys {
+    const val PATH = "/settings"
+    const val KEY_DAILY_STEP_GOAL = "daily_step_goal"
+    const val KEY_INACTIVITY_THRESHOLD = "inactivity_threshold_min"
+    const val KEY_ACTIVE_HOURS_START = "active_hours_start"
+    const val KEY_ACTIVE_HOURS_END = "active_hours_end"
+    const val KEY_CONTEXT_AWARE_ENABLED = "context_aware_enabled"
+    const val KEY_END_OF_DAY_HOUR = "end_of_day_hour"
+    const val KEY_BEHIND_PACE_CHECK_HOUR = "behind_pace_check_hour"
+}

--- a/shared/src/main/java/com/meatsack/shared/sync/SettingsSnapshot.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/SettingsSnapshot.kt
@@ -5,7 +5,8 @@ import com.google.android.gms.wearable.DataMap
 /**
  * Wire-shape for the /settings DataItem channel. Single source of truth for the
  * field set — adding a property here forces both phone (writer) and watch
- * (reader) to handle the new field, which is the structural fix for issue #23.
+ * (reader) to handle the new field — centralizing the field set prevents the
+ * phone-side and watch-side from drifting independently.
  *
  * fromDataMap returns SettingsDefaults values for any missing keys (forward
  * and backward compatibility) and coerces hour fields to 0..23 (defense in

--- a/shared/src/main/java/com/meatsack/shared/sync/SettingsSnapshot.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/SettingsSnapshot.kt
@@ -1,0 +1,56 @@
+package com.meatsack.shared.sync
+
+import com.google.android.gms.wearable.DataMap
+
+/**
+ * Wire-shape for the /settings DataItem channel. Single source of truth for the
+ * field set — adding a property here forces both phone (writer) and watch
+ * (reader) to handle the new field, which is the structural fix for issue #23.
+ *
+ * fromDataMap returns SettingsDefaults values for any missing keys (forward
+ * and backward compatibility) and coerces hour fields to 0..23 (defense in
+ * depth against malformed payloads; phone's validateHour should already
+ * prevent invalid sends).
+ */
+data class SettingsSnapshot(
+    val dailyStepGoal: Int,
+    val inactivityThreshold: Int,
+    val activeHoursStart: Int,
+    val activeHoursEnd: Int,
+    val contextAwareEnabled: Boolean,
+    val endOfDayHour: Int,
+    val behindPaceCheckHour: Int,
+) {
+
+    fun toDataMap(dm: DataMap) {
+        dm.putInt(SettingsKeys.KEY_DAILY_STEP_GOAL, dailyStepGoal)
+        dm.putInt(SettingsKeys.KEY_INACTIVITY_THRESHOLD, inactivityThreshold)
+        dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_START, activeHoursStart)
+        dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_END, activeHoursEnd)
+        dm.putBoolean(SettingsKeys.KEY_CONTEXT_AWARE_ENABLED, contextAwareEnabled)
+        dm.putInt(SettingsKeys.KEY_END_OF_DAY_HOUR, endOfDayHour)
+        dm.putInt(SettingsKeys.KEY_BEHIND_PACE_CHECK_HOUR, behindPaceCheckHour)
+    }
+
+    companion object {
+        val defaults = SettingsSnapshot(
+            dailyStepGoal = SettingsDefaults.DAILY_STEP_GOAL,
+            inactivityThreshold = SettingsDefaults.INACTIVITY_THRESHOLD_MIN,
+            activeHoursStart = SettingsDefaults.ACTIVE_HOURS_START,
+            activeHoursEnd = SettingsDefaults.ACTIVE_HOURS_END,
+            contextAwareEnabled = SettingsDefaults.CONTEXT_AWARE_ENABLED,
+            endOfDayHour = SettingsDefaults.END_OF_DAY_HOUR,
+            behindPaceCheckHour = SettingsDefaults.BEHIND_PACE_CHECK_HOUR,
+        )
+
+        fun fromDataMap(dm: DataMap): SettingsSnapshot = SettingsSnapshot(
+            dailyStepGoal = dm.getInt(SettingsKeys.KEY_DAILY_STEP_GOAL, defaults.dailyStepGoal),
+            inactivityThreshold = dm.getInt(SettingsKeys.KEY_INACTIVITY_THRESHOLD, defaults.inactivityThreshold),
+            activeHoursStart = dm.getInt(SettingsKeys.KEY_ACTIVE_HOURS_START, defaults.activeHoursStart).coerceIn(0, 23),
+            activeHoursEnd = dm.getInt(SettingsKeys.KEY_ACTIVE_HOURS_END, defaults.activeHoursEnd).coerceIn(0, 23),
+            contextAwareEnabled = dm.getBoolean(SettingsKeys.KEY_CONTEXT_AWARE_ENABLED, defaults.contextAwareEnabled),
+            endOfDayHour = dm.getInt(SettingsKeys.KEY_END_OF_DAY_HOUR, defaults.endOfDayHour).coerceIn(0, 23),
+            behindPaceCheckHour = dm.getInt(SettingsKeys.KEY_BEHIND_PACE_CHECK_HOUR, defaults.behindPaceCheckHour).coerceIn(0, 23),
+        )
+    }
+}

--- a/shared/src/test/java/com/meatsack/shared/sync/SettingsSnapshotTest.kt
+++ b/shared/src/test/java/com/meatsack/shared/sync/SettingsSnapshotTest.kt
@@ -1,0 +1,58 @@
+package com.meatsack.shared.sync
+
+import com.google.android.gms.wearable.DataMap
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SettingsSnapshotTest {
+
+    @Test
+    fun defaults_matchSettingsDefaults() {
+        val snap = SettingsSnapshot.defaults
+        assertEquals(SettingsDefaults.DAILY_STEP_GOAL, snap.dailyStepGoal)
+        assertEquals(SettingsDefaults.INACTIVITY_THRESHOLD_MIN, snap.inactivityThreshold)
+        assertEquals(SettingsDefaults.ACTIVE_HOURS_START, snap.activeHoursStart)
+        assertEquals(SettingsDefaults.ACTIVE_HOURS_END, snap.activeHoursEnd)
+        assertEquals(SettingsDefaults.CONTEXT_AWARE_ENABLED, snap.contextAwareEnabled)
+        assertEquals(SettingsDefaults.END_OF_DAY_HOUR, snap.endOfDayHour)
+        assertEquals(SettingsDefaults.BEHIND_PACE_CHECK_HOUR, snap.behindPaceCheckHour)
+    }
+
+    @Test
+    fun toDataMap_fromDataMap_roundTrip() {
+        val original = SettingsSnapshot(
+            dailyStepGoal = 12_345,
+            inactivityThreshold = 45,
+            activeHoursStart = 8,
+            activeHoursEnd = 21,
+            contextAwareEnabled = true,
+            endOfDayHour = 20,
+            behindPaceCheckHour = 14,
+        )
+        val dm = DataMap()
+        original.toDataMap(dm)
+        val parsed = SettingsSnapshot.fromDataMap(dm)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun fromDataMap_missingKeys_returnsDefaults() {
+        val dm = DataMap() // empty
+        val parsed = SettingsSnapshot.fromDataMap(dm)
+        assertEquals(SettingsSnapshot.defaults, parsed)
+    }
+
+    @Test
+    fun fromDataMap_outOfRangeHours_clampedTo0to23() {
+        val dm = DataMap()
+        dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_START, -5)
+        dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_END, 99)
+        dm.putInt(SettingsKeys.KEY_END_OF_DAY_HOUR, 24)
+        dm.putInt(SettingsKeys.KEY_BEHIND_PACE_CHECK_HOUR, -1)
+        val parsed = SettingsSnapshot.fromDataMap(dm)
+        assertEquals(0, parsed.activeHoursStart)
+        assertEquals(23, parsed.activeHoursEnd)
+        assertEquals(23, parsed.endOfDayHour)
+        assertEquals(0, parsed.behindPaceCheckHour)
+    }
+}

--- a/shared/src/test/java/com/meatsack/shared/sync/SettingsSnapshotTest.kt
+++ b/shared/src/test/java/com/meatsack/shared/sync/SettingsSnapshotTest.kt
@@ -45,6 +45,8 @@ class SettingsSnapshotTest {
     @Test
     fun fromDataMap_outOfRangeHours_clampedTo0to23() {
         val dm = DataMap()
+        // Non-hour fields intentionally absent — fromDataMap returns defaults
+        // for them, verified separately in fromDataMap_missingKeys_returnsDefaults.
         dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_START, -5)
         dm.putInt(SettingsKeys.KEY_ACTIVE_HOURS_END, 99)
         dm.putInt(SettingsKeys.KEY_END_OF_DAY_HOUR, 24)

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -62,6 +62,18 @@
             </intent-filter>
         </service>
 
+        <service
+            android:name=".sync.WatchSettingsReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+                <data
+                    android:scheme="wear"
+                    android:host="*"
+                    android:pathPrefix="/settings" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
@@ -51,10 +51,10 @@ class MeatsackWearService : Service() {
         super.onCreate()
         val db = AppDatabase.getDatabase(applicationContext)
         healthTracker = HealthTracker(applicationContext)
-        escalationManager = EscalationManager()
+        settings = WatchSettingsCache(applicationContext)
+        escalationManager = EscalationManager(thresholdProvider = { settings.inactivityThreshold })
         messageRepo = MessageRepository(db.messageDao())
         notificationService = InsultNotificationService(applicationContext)
-        settings = WatchSettingsCache(applicationContext)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/wear/src/main/java/com/meatsack/motivator/escalation/EscalationManager.kt
+++ b/wear/src/main/java/com/meatsack/motivator/escalation/EscalationManager.kt
@@ -1,11 +1,14 @@
 package com.meatsack.motivator.escalation
 
 import com.meatsack.shared.constants.EscalationLevel
+import com.meatsack.shared.sync.SettingsDefaults
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class EscalationManager {
+class EscalationManager(
+    private val thresholdProvider: () -> Int = { SettingsDefaults.INACTIVITY_THRESHOLD_MIN },
+) {
     private val _currentLevel = MutableStateFlow(EscalationLevel.AGGRESSIVE)
     val currentLevel: StateFlow<EscalationLevel> = _currentLevel.asStateFlow()
 
@@ -54,7 +57,7 @@ class EscalationManager {
      */
     fun shouldTrigger(minutesIdle: Int): Boolean {
         if (isSnoozed && System.currentTimeMillis() < snoozeUntil) return false
-        val threshold = EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT
+        val threshold = thresholdProvider()
         if (minutesIdle < threshold) return false
         val interval = EscalationLevel.ESCALATION_INTERVAL_MINUTES
         val last = lastFiredAtIdle ?: return true
@@ -64,7 +67,7 @@ class EscalationManager {
     fun isCurrentlySnoozed(): Boolean = isSnoozed && System.currentTimeMillis() < snoozeUntil
 
     private fun calculateLevel(minutesIdle: Int): EscalationLevel {
-        val threshold = EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT
+        val threshold = thresholdProvider()
         val interval = EscalationLevel.ESCALATION_INTERVAL_MINUTES
         val minutesPastThreshold = maxOf(0, minutesIdle - threshold)
         val escalations = minutesPastThreshold / interval

--- a/wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
+++ b/wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
@@ -1,6 +1,7 @@
 package com.meatsack.motivator.settings
 
 import android.content.Context
+import com.meatsack.shared.sync.SettingsDefaults
 
 /**
  * Cache of user settings mirrored from the phone. Populated by a
@@ -11,27 +12,27 @@ class WatchSettingsCache(context: Context) {
     private val prefs = context.getSharedPreferences("watch_settings", Context.MODE_PRIVATE)
 
     var contextAwareEnabled: Boolean
-        get() = prefs.getBoolean(KEY_CONTEXT_AWARE, false)
+        get() = prefs.getBoolean(KEY_CONTEXT_AWARE, SettingsDefaults.CONTEXT_AWARE_ENABLED)
         set(value) = prefs.edit().putBoolean(KEY_CONTEXT_AWARE, value).apply()
 
     var activeHoursStart: Int
-        get() = prefs.getInt(KEY_ACTIVE_START, 7)
+        get() = prefs.getInt(KEY_ACTIVE_START, SettingsDefaults.ACTIVE_HOURS_START)
         set(value) = prefs.edit().putInt(KEY_ACTIVE_START, value).apply()
 
     var activeHoursEnd: Int
-        get() = prefs.getInt(KEY_ACTIVE_END, 22)
+        get() = prefs.getInt(KEY_ACTIVE_END, SettingsDefaults.ACTIVE_HOURS_END)
         set(value) = prefs.edit().putInt(KEY_ACTIVE_END, value).apply()
 
     var dailyStepGoal: Int
-        get() = prefs.getInt(KEY_GOAL, 10_000)
+        get() = prefs.getInt(KEY_GOAL, SettingsDefaults.DAILY_STEP_GOAL)
         set(value) = prefs.edit().putInt(KEY_GOAL, value).apply()
 
     var endOfDayHour: Int
-        get() = prefs.getInt(KEY_END_OF_DAY, 21)
+        get() = prefs.getInt(KEY_END_OF_DAY, SettingsDefaults.END_OF_DAY_HOUR)
         set(value) = prefs.edit().putInt(KEY_END_OF_DAY, value).apply()
 
     var behindPaceCheckHour: Int
-        get() = prefs.getInt(KEY_BEHIND_PACE_HOUR, 12)
+        get() = prefs.getInt(KEY_BEHIND_PACE_HOUR, SettingsDefaults.BEHIND_PACE_CHECK_HOUR)
         set(value) = prefs.edit().putInt(KEY_BEHIND_PACE_HOUR, value).apply()
 
     companion object {

--- a/wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
+++ b/wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
@@ -4,9 +4,8 @@ import android.content.Context
 import com.meatsack.shared.sync.SettingsDefaults
 
 /**
- * Cache of user settings mirrored from the phone. Populated by a
- * future settings-sync DataItem (Task 16); reads default values until
- * the first sync.
+ * Cache of user settings mirrored from the phone over the /settings DataItem.
+ * Reads SettingsDefaults until the first sync arrives.
  */
 class WatchSettingsCache(context: Context) {
     private val prefs = context.getSharedPreferences("watch_settings", Context.MODE_PRIVATE)

--- a/wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
+++ b/wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
@@ -5,7 +5,7 @@ import com.meatsack.shared.sync.SettingsDefaults
 
 /**
  * Cache of user settings mirrored from the phone over the /settings DataItem.
- * Reads SettingsDefaults until the first sync arrives.
+ * Each key falls back to SettingsDefaults until that key has been written by a sync.
  */
 class WatchSettingsCache(context: Context) {
     private val prefs = context.getSharedPreferences("watch_settings", Context.MODE_PRIVATE)

--- a/wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
+++ b/wear/src/main/java/com/meatsack/motivator/settings/WatchSettingsCache.kt
@@ -34,6 +34,10 @@ class WatchSettingsCache(context: Context) {
         get() = prefs.getInt(KEY_BEHIND_PACE_HOUR, SettingsDefaults.BEHIND_PACE_CHECK_HOUR)
         set(value) = prefs.edit().putInt(KEY_BEHIND_PACE_HOUR, value).apply()
 
+    var inactivityThreshold: Int
+        get() = prefs.getInt(KEY_INACTIVITY_THRESHOLD, SettingsDefaults.INACTIVITY_THRESHOLD_MIN)
+        set(value) = prefs.edit().putInt(KEY_INACTIVITY_THRESHOLD, value).apply()
+
     companion object {
         private const val KEY_CONTEXT_AWARE = "context_aware_enabled"
         private const val KEY_ACTIVE_START = "active_hours_start"
@@ -41,5 +45,6 @@ class WatchSettingsCache(context: Context) {
         private const val KEY_GOAL = "daily_step_goal"
         private const val KEY_END_OF_DAY = "end_of_day_hour"
         private const val KEY_BEHIND_PACE_HOUR = "behind_pace_check_hour"
+        private const val KEY_INACTIVITY_THRESHOLD = "inactivity_threshold_min"
     }
 }

--- a/wear/src/main/java/com/meatsack/motivator/sync/WatchSettingsReceiver.kt
+++ b/wear/src/main/java/com/meatsack/motivator/sync/WatchSettingsReceiver.kt
@@ -1,0 +1,82 @@
+package com.meatsack.motivator.sync
+
+import android.util.Log
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.WearableListenerService
+import com.meatsack.motivator.settings.WatchSettingsCache
+import com.meatsack.shared.sync.SettingsKeys
+import com.meatsack.shared.sync.SettingsSnapshot
+
+class WatchSettingsReceiver : WearableListenerService() {
+
+    companion object {
+        private const val TAG = "WatchSettingsReceiver"
+
+        /**
+         * Pure function. Apply the snapshot field-by-field to the sink.
+         * Extracted so unit tests don't need a WearableListenerService instance.
+         */
+        fun applySnapshot(snap: SettingsSnapshot, sink: ApplySink) {
+            sink.setDailyStepGoal(snap.dailyStepGoal)
+            sink.setInactivityThreshold(snap.inactivityThreshold)
+            sink.setActiveHoursStart(snap.activeHoursStart)
+            sink.setActiveHoursEnd(snap.activeHoursEnd)
+            sink.setContextAwareEnabled(snap.contextAwareEnabled)
+            sink.setEndOfDayHour(snap.endOfDayHour)
+            sink.setBehindPaceCheckHour(snap.behindPaceCheckHour)
+        }
+    }
+
+    /** Minimal write surface that WatchSettingsCache satisfies via cacheAdapter(). */
+    interface ApplySink {
+        fun setDailyStepGoal(v: Int)
+        fun setInactivityThreshold(v: Int)
+        fun setActiveHoursStart(v: Int)
+        fun setActiveHoursEnd(v: Int)
+        fun setContextAwareEnabled(v: Boolean)
+        fun setEndOfDayHour(v: Int)
+        fun setBehindPaceCheckHour(v: Int)
+    }
+
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        dataEvents.forEach { event ->
+            val path = event.dataItem.uri.path
+            if (path != SettingsKeys.PATH) return@forEach
+            val sourceNode = event.dataItem.uri.host
+            try {
+                val dm = DataMapItem.fromDataItem(event.dataItem).dataMap
+                val snap = SettingsSnapshot.fromDataMap(dm)
+                val cache = WatchSettingsCache(applicationContext)
+                applySnapshot(snap, cacheAdapter(cache))
+                Log.d(TAG, "Applied settings from node=$sourceNode: $snap")
+            } catch (t: Throwable) {
+                Log.e(TAG, "Failed to apply settings from node=$sourceNode", t)
+            }
+        }
+    }
+
+    private fun cacheAdapter(cache: WatchSettingsCache): ApplySink = object : ApplySink {
+        override fun setDailyStepGoal(v: Int) {
+            cache.dailyStepGoal = v
+        }
+        override fun setInactivityThreshold(v: Int) {
+            cache.inactivityThreshold = v
+        }
+        override fun setActiveHoursStart(v: Int) {
+            cache.activeHoursStart = v
+        }
+        override fun setActiveHoursEnd(v: Int) {
+            cache.activeHoursEnd = v
+        }
+        override fun setContextAwareEnabled(v: Boolean) {
+            cache.contextAwareEnabled = v
+        }
+        override fun setEndOfDayHour(v: Int) {
+            cache.endOfDayHour = v
+        }
+        override fun setBehindPaceCheckHour(v: Int) {
+            cache.behindPaceCheckHour = v
+        }
+    }
+}

--- a/wear/src/test/java/com/meatsack/motivator/escalation/EscalationManagerTest.kt
+++ b/wear/src/test/java/com/meatsack/motivator/escalation/EscalationManagerTest.kt
@@ -104,4 +104,22 @@ class EscalationManagerTest {
         assertFalse(manager.shouldTrigger(30))
         assertFalse(manager.shouldTrigger(120))
     }
+
+    @Test
+    fun `custom threshold provider overrides default`() {
+        val customManager = EscalationManager(thresholdProvider = { 45 })
+        assertFalse("44 is below custom threshold 45", customManager.shouldTrigger(44))
+        assertTrue("45 should trigger", customManager.shouldTrigger(45))
+    }
+
+    @Test
+    fun `provider is called per shouldTrigger invocation (live config)`() {
+        var threshold = 30
+        val liveManager = EscalationManager(thresholdProvider = { threshold })
+        assertTrue("30 triggers with threshold=30", liveManager.shouldTrigger(30))
+        liveManager.onMovementDetected() // reset
+        threshold = 60
+        assertFalse("30 should not trigger after raising threshold to 60", liveManager.shouldTrigger(30))
+        assertTrue("60 triggers with threshold=60", liveManager.shouldTrigger(60))
+    }
 }

--- a/wear/src/test/java/com/meatsack/motivator/sync/WatchSettingsReceiverTest.kt
+++ b/wear/src/test/java/com/meatsack/motivator/sync/WatchSettingsReceiverTest.kt
@@ -1,0 +1,64 @@
+package com.meatsack.motivator.sync
+
+import com.meatsack.shared.sync.SettingsSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WatchSettingsReceiverTest {
+
+    /** Map-backed fake that records all writes. */
+    private class FakeApplySink : WatchSettingsReceiver.ApplySink {
+        // Use distinct backing field names to avoid JVM signature clash with the
+        // interface methods (e.g. setDailyStepGoal vs Kotlin's generated setter).
+        var recordedDailyStepGoal: Int = -1
+        var recordedInactivityThreshold: Int = -1
+        var recordedActiveHoursStart: Int = -1
+        var recordedActiveHoursEnd: Int = -1
+        var recordedContextAwareEnabled: Boolean = false
+        var recordedEndOfDayHour: Int = -1
+        var recordedBehindPaceCheckHour: Int = -1
+        override fun setDailyStepGoal(v: Int) {
+            recordedDailyStepGoal = v
+        }
+        override fun setInactivityThreshold(v: Int) {
+            recordedInactivityThreshold = v
+        }
+        override fun setActiveHoursStart(v: Int) {
+            recordedActiveHoursStart = v
+        }
+        override fun setActiveHoursEnd(v: Int) {
+            recordedActiveHoursEnd = v
+        }
+        override fun setContextAwareEnabled(v: Boolean) {
+            recordedContextAwareEnabled = v
+        }
+        override fun setEndOfDayHour(v: Int) {
+            recordedEndOfDayHour = v
+        }
+        override fun setBehindPaceCheckHour(v: Int) {
+            recordedBehindPaceCheckHour = v
+        }
+    }
+
+    @Test
+    fun applySnapshot_writesEveryField() {
+        val sink = FakeApplySink()
+        val snap = SettingsSnapshot(
+            dailyStepGoal = 12_000,
+            inactivityThreshold = 45,
+            activeHoursStart = 8,
+            activeHoursEnd = 21,
+            contextAwareEnabled = true,
+            endOfDayHour = 20,
+            behindPaceCheckHour = 14,
+        )
+        WatchSettingsReceiver.applySnapshot(snap, sink)
+        assertEquals(12_000, sink.recordedDailyStepGoal)
+        assertEquals(45, sink.recordedInactivityThreshold)
+        assertEquals(8, sink.recordedActiveHoursStart)
+        assertEquals(21, sink.recordedActiveHoursEnd)
+        assertEquals(true, sink.recordedContextAwareEnabled)
+        assertEquals(20, sink.recordedEndOfDayHour)
+        assertEquals(14, sink.recordedBehindPaceCheckHour)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `/settings` Wear Data Layer channel carrying the 7 watch-relevant settings via DataMap-native typed keys.
- New shared types: `SettingsKeys`, `SettingsSnapshot` (with `toDataMap`/`fromDataMap` + `coerceIn(0..23)` for hour fields), and hoisted `SettingsDefaults` — single source of truth that makes future schema drift a compile error.
- `PhoneSettingsSyncer` observes `SettingsRepository` flows (debounce 500ms + distinctUntilChanged + bounded retryWhen) and exposes `syncNow()` called from `MainActivity.onResume`.
- `WatchSettingsReceiver` consumes `/settings` and applies into `WatchSettingsCache`. Pure `applySnapshot` factored for unit testing.
- Adds `behindPaceCheckHour` slider to phone UI (was watch-only with a hardcoded default).
- Rewires `EscalationManager` to read `inactivityThreshold` from `WatchSettingsCache` via injected `thresholdProvider: () -> Int` lambda (was hardcoded to `EscalationLevel.INACTIVITY_THRESHOLD_MINUTES_DEFAULT`).

Closes #23. Partially addresses #25 (defense-in-depth `coerceIn` on the wire).

## Implementation notes
- Workflow: spec → plan → subagent-driven implementation, 13 plan tasks across 14 commits.
- Spec: `docs/superpowers/specs/2026-05-30-phone-watch-settings-sync-design.md`
- Plan: `docs/superpowers/plans/2026-05-30-phone-watch-settings-sync.md`
- `:shared` now declares `play-services-wearable` (required for `DataMap` to be referenceable in shared types). `:mobile` test classpath gains `kotlinx-coroutines-test` (for virtual-time debounce tests) and `testOptions.unitTests.isReturnDefaultValues = true` (so JVM unit tests don't choke on unmocked `android.util.Log`).

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest :mobile:testDebugUnitTest :wear:testDebugUnitTest` — all green
- [x] `./gradlew build` — BUILD SUCCESSFUL (includes spotlessCheck)
- [ ] Manual end-to-end on paired emulators per spec checklist (deferred — no emulator in CI):
  - Edit `Daily step goal` slider on phone, observe watch logcat `WatchSettingsReceiver: Applied settings from node=...` within ~2 sec
  - Toggle `Context-aware language`; verify boolean propagated
  - Adjust `Behind-pace check hour`; verify new slider works + propagates
  - Force-stop phone app + relaunch; verify one snapshot fires from `onResume`
  - Pull pairing offline, change a setting, restore; verify DataClient delivers queued DataItem
- [ ] Verify `EscalationManager` uses synced threshold (drop `INACTIVITY_THRESHOLD_MINUTES_DEFAULT` to 1 per CLAUDE.md guidance, then change phone slider, observe behavior on watch)

## Follow-ups deliberately out of scope
- #21 — surface setter validation exceptions to UI
- #24 — harden worker bodies against silent DAO/notifier throws
- #25 — `WatchSettingsCache.coerceIn(0..23)` defense at *read* time (this PR covers the wire-side coerce in `fromDataMap`; cache itself still trusts stored values)
- Decide whether/how `quietHoursStart`/`quietHoursEnd` should reach the watch (file new issue)
- Surface `endOfDayHour` in the phone UI (`SettingsViewModel` exposes it but `SettingsScreen.kt` has no picker — discovered while writing the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Manual E2E discovery — blocked by pre-existing issue #36

Attempted manual end-to-end on paired emulators per the test plan above. **All `/settings` DataItem writes from the phone succeeded but never reached the watch.** Investigation revealed a pre-existing v1 bug: the phone (`com.meatsack.motivator.mobile`) and watch (`com.meatsack.motivator`) declare different `applicationId`s, which Google's Wear Data Layer requires to match. Independently verified that the existing v1 `/messages` sync (`PhoneSyncSender → WatchSyncReceiver`) is also broken for the same reason — v1 only appeared to work because the watch also seeds its own DB on first launch (commit `f232963`), masking the broken sync.

Tracking the transport fix in #36. The code in this PR is correct — Wear Data Layer-side logic, debouncing, retry, error handling, structural-fix invariants all behave as designed in unit tests. E2E verification will become possible once #36 lands.

This PR ships as-is for its structural value (single source of truth via `SettingsSnapshot` + `SettingsKeys` + `SettingsDefaults`, eliminating the schema drift that motivated #23). Once #36 lands, all the deferred manual E2E checks in this PR's test plan become executable in their current form with no code changes.
