### PR TITLE
Align phone+watch applicationId so Wear DataItems propagate (closes #36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,24 @@ Because the watch foreground service has `type="health"`, `ACTIVITY_RECOGNITION`
 adb -s emulator-5556 shell pm grant com.meatsack.motivator android.permission.ACTIVITY_RECOGNITION
 ```
 
+### Installing without cross-contamination
+
+The phone and watch modules now share `applicationId = com.meatsack.motivator` (required for Wear Data Layer DataItem propagation). The wear manifest declares `<uses-feature android:name="android.hardware.type.watch" android:required="true"/>` so `:wear:installDebug` auto-targets only the watch. The `:mobile:installDebug` task does **not** form-factor-filter — it will install on both emulators by default, which overwrites the watch's APK.
+
+Recommended dev install procedure (target each device explicitly):
+
+```bash
+./gradlew :mobile:assembleDebug :wear:assembleDebug
+adb -s emulator-5556 install -r mobile/build/outputs/apk/debug/mobile-debug.apk     # phone only
+adb -s emulator-5554 install -r wear/build/outputs/apk/debug/wear-debug.apk         # watch only
+```
+
+If you accidentally cross-install (or had separate `applicationId`s before the pre-existing v1 sync bug was fixed), uninstall first:
+
+```bash
+adb -s <device-id> uninstall com.meatsack.motivator
+```
+
 ## Git Workflow
 
 - **Do not commit to `main`.** Work lives on feature branches (e.g., `feature/v1-implementation`). PR into `main`.

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -11,7 +11,10 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.meatsack.motivator.mobile"
+        // Must match the wear module's applicationId for Wear Data Layer
+        // DataItem propagation to work (closes #36). namespace stays separate
+        // so the Kotlin code package remains com.meatsack.motivator.mobile.
+        applicationId = "com.meatsack.motivator"
         minSdk = 26
         targetSdk = 36
         versionCode = 1

--- a/mobile/src/androidTest/java/com/meatsack/motivator/mobile/ExampleInstrumentedTest.kt
+++ b/mobile/src/androidTest/java/com/meatsack/motivator/mobile/ExampleInstrumentedTest.kt
@@ -11,6 +11,6 @@ class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.meatsack.motivator.mobile", appContext.packageName)
+        assertEquals("com.meatsack.motivator", appContext.packageName)
     }
 }

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Required for Wear OS device filtering: this APK only installs on watches. -->
+    <!-- Paired with the mobile APK now sharing applicationId; see #36. -->
+    <uses-feature android:name="android.hardware.type.watch" android:required="true" />
+
     <uses-permission android:name="android.permission.BODY_SENSORS" />
     <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND"
         android:maxSdkVersion="32" />


### PR DESCRIPTION
## Summary
- Changes `mobile/build.gradle.kts` `applicationId` from `com.meatsack.motivator.mobile` → `com.meatsack.motivator` so it matches the wear module. Wear Data Layer requires matching `applicationId` + signing key for DataItems to propagate between paired devices.
- Adds `<uses-feature android:name="android.hardware.type.watch" android:required="true"/>` to the wear `AndroidManifest.xml` so the wear APK only installs on watches. Without this, the now-shared `applicationId` lets `:mobile:installDebug` overwrite the wear APK.
- Updates CLAUDE.md with the new install procedure (target each device explicitly with `adb -s <id> install -r ...`) and the uninstall recovery path.

`namespace = com.meatsack.motivator.mobile` on the phone module is unchanged — Kotlin code package stays the same. Only the published identity (`applicationId`) moves.

Closes #36. Unblocks manual E2E for #28.

## Why this was hidden until now
The v1 `/messages` sync (`PhoneSyncSender → WatchSyncReceiver`) appeared to work because the watch also seeds its own DB on first launch (`f232963`). The seed data masked the broken transport. Independently verified during PR #28 E2E attempt that both `/messages` and `/settings` write success on the phone but never arrive on the watch — confirmed via `dumpsys` showing zero `com.meatsack.motivator` DataItems on the watch despite `1 connected out of 1` pairing health.

## Side effect
Existing installs with the old `applicationId` are orphans — the new APK won't upgrade them in place. Users must uninstall the old phone app before installing the new one:
```bash
adb -s <phone-id> uninstall com.meatsack.motivator.mobile   # remove the old install
adb -s <phone-id> install -r mobile/build/outputs/apk/debug/mobile-debug.apk
```
Production has no users yet, so the cost is zero.

## Test plan
- [x] `./gradlew :mobile:assembleDebug :wear:assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew :shared:testDebugUnitTest :mobile:testDebugUnitTest :wear:testDebugUnitTest` — pre-commit hook ran, all green
- [ ] Manual E2E on paired emulators (now expected to actually work):
  - Uninstall both old APKs from both emulators
  - Install fresh: `adb -s <phone-id> install -r mobile/build/outputs/apk/debug/mobile-debug.apk` + `adb -s <watch-id> install -r wear/build/outputs/apk/debug/wear-debug.apk`
  - Re-grant `ACTIVITY_RECOGNITION` on the watch
  - Launch both apps
  - Tap **Sync to Watch** in the phone Library tab — confirm watch logcat shows `WatchSyncReceiver: Stored N messages from node=...`
  - Drag a phone settings slider — confirm watch logcat shows `WatchSettingsReceiver: Applied settings from node=...`

## Follow-up after this lands
- Re-attempt PR #28's manual E2E checklist — should now pass.
- Consider whether the orphan-install cost is worth a one-time migration note in the README. (Not currently included since the app has no production users.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)