### PR TITLE
Play-compliant votable insult notifications (drop full-screen intent)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.idea/
 /.kotlin/
 /.claude/
+/.superpowers/
 .DS_Store
 /build
 /captures

--- a/docs/superpowers/plans/2026-06-07-play-compliant-vote-notifications.md
+++ b/docs/superpowers/plans/2026-06-07-play-compliant-vote-notifications.md
@@ -1,0 +1,689 @@
+# Play-Compliant Vote Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the full-screen-intent voting takeover with HIGH-importance notification action buttons (👎/👍) handled by a `BroadcastReceiver`, so every insult is votable directly on the notification — Play-compliant, no restricted permission.
+
+**Architecture:** `InsultNotificationService` posts a notification carrying two vote-action `PendingIntent`s (broadcasts to a new `VoteReceiver`) plus a `contentIntent` to the existing `InsultActivity`. `VoteReceiver` records the vote on `MeatsackWearApp.applicationScope` via `MessageRepository` and dismisses the notification. All FSI machinery is removed. The existing debug-only `TestFireActivity` is repurposed to fire the real notification for on-device verification.
+
+**Tech Stack:** Kotlin, AndroidX `NotificationCompat`, Room (`:shared`), JUnit (`:wear` unit tests). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-play-compliant-vote-notification-design.md`
+
+---
+
+## File Structure
+
+### New
+
+| Path | Responsibility |
+|---|---|
+| `wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt` | BroadcastReceiver for vote actions + the pure `VoteAction`/`requestCode` contract. |
+| `wear/src/test/java/com/meatsack/motivator/notification/VoteReceiverTest.kt` | Unit tests for `VoteAction.from` and `VoteReceiver.requestCode`. |
+| `wear/src/main/res/drawable/ic_thumb_up.xml` | Vector icon for the 👍 action. |
+| `wear/src/main/res/drawable/ic_thumb_down.xml` | Vector icon for the 👎 action. |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt` | Drop `setFullScreenIntent`; add vote actions + `contentIntent` + `BigTextStyle` + `setTimeoutAfter`; id = `message.id.toInt()`; category `REMINDER`. |
+| `wear/src/main/AndroidManifest.xml` | Remove `USE_FULL_SCREEN_INTENT`; remove `showOnLockScreen`/`turnScreenOn` from `InsultActivity`; register `VoteReceiver`. |
+| `wear/src/debug/java/com/meatsack/motivator/debug/TestFireActivity.kt` | Fire the real notification via `deliverInsult` instead of launching `InsultActivity` directly. |
+
+### Already satisfied (no change)
+
+- `MainActivity` already requests `POST_NOTIFICATIONS` at runtime (lines 18-21). Verified, no task.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0: Confirm branch**
+
+Run: `git branch --show-current`
+Expected: `feature/play-compliant-vote-notifications`. If not: `git checkout feature/play-compliant-vote-notifications`.
+
+---
+
+## Task 1: Vote contract — `VoteAction` + `requestCode` (TDD, pure)
+
+These are pure functions with no Android dependencies, so they're unit-tested first.
+
+**Files:**
+- Create: `wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt`
+- Test: `wear/src/test/java/com/meatsack/motivator/notification/VoteReceiverTest.kt`
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `wear/src/test/java/com/meatsack/motivator/notification/VoteReceiverTest.kt`:
+
+```kotlin
+package com.meatsack.motivator.notification
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class VoteReceiverTest {
+
+    @Test
+    fun from_upVote_returnsUp() {
+        assertEquals(VoteReceiver.VoteAction.Up(5L), VoteReceiver.VoteAction.from(5L, isUp = true))
+    }
+
+    @Test
+    fun from_downVote_returnsDown() {
+        assertEquals(VoteReceiver.VoteAction.Down(5L), VoteReceiver.VoteAction.from(5L, isUp = false))
+    }
+
+    @Test
+    fun from_invalidId_returnsIgnore() {
+        assertEquals(VoteReceiver.VoteAction.Ignore, VoteReceiver.VoteAction.from(0L, isUp = true))
+        assertEquals(VoteReceiver.VoteAction.Ignore, VoteReceiver.VoteAction.from(-1L, isUp = false))
+    }
+
+    @Test
+    fun requestCode_upAndDownDiffer_forSameMessage() {
+        assertNotEquals(
+            VoteReceiver.requestCode(7L, isUp = true),
+            VoteReceiver.requestCode(7L, isUp = false),
+        )
+    }
+
+    @Test
+    fun requestCode_differsAcrossMessages() {
+        assertNotEquals(
+            VoteReceiver.requestCode(7L, isUp = true),
+            VoteReceiver.requestCode(8L, isUp = true),
+        )
+    }
+}
+```
+
+- [ ] **Step 1.2: Run the tests, expecting failure (unresolved reference)**
+
+Run: `./gradlew :wear:testDebugUnitTest --tests "com.meatsack.motivator.notification.VoteReceiverTest"`
+Expected: FAIL — `VoteReceiver` does not exist yet (compilation error).
+
+- [ ] **Step 1.3: Create `VoteReceiver` with the pure contract only**
+
+Create `wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt`:
+
+```kotlin
+package com.meatsack.motivator.notification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationManagerCompat
+import com.meatsack.motivator.MeatsackWearApp
+import com.meatsack.motivator.messages.MessageRepository
+import com.meatsack.shared.db.AppDatabase
+import kotlinx.coroutines.launch
+
+/**
+ * Records a 👍/👎 vote tapped directly on an insult notification, then dismisses
+ * that notification. Runs on the app scope so the DB write outlives this receiver.
+ */
+class VoteReceiver : BroadcastReceiver() {
+
+    /** Pure result of interpreting a vote intent — unit-testable without Android. */
+    sealed class VoteAction {
+        data class Up(val messageId: Long) : VoteAction()
+        data class Down(val messageId: Long) : VoteAction()
+        object Ignore : VoteAction()
+
+        companion object {
+            fun from(messageId: Long, isUp: Boolean): VoteAction = when {
+                messageId <= 0L -> Ignore
+                isUp -> Up(messageId)
+                else -> Down(messageId)
+            }
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val messageId = intent.getLongExtra(InsultNotificationService.EXTRA_MESSAGE_ID, -1L)
+        val isUp = intent.getBooleanExtra(EXTRA_VOTE_UP, true)
+        val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+
+        // Acknowledge the tap immediately by dismissing the notification.
+        if (notifId > 0) NotificationManagerCompat.from(context).cancel(notifId)
+
+        val action = VoteAction.from(messageId, isUp)
+        if (action is VoteAction.Ignore) return
+
+        val app = context.applicationContext as MeatsackWearApp
+        val pending = goAsync()
+        app.applicationScope.launch {
+            try {
+                val repo = MessageRepository(AppDatabase.getDatabase(context).messageDao())
+                when (action) {
+                    is VoteAction.Up -> repo.voteUp(action.messageId)
+                    is VoteAction.Down -> repo.voteDown(action.messageId)
+                    VoteAction.Ignore -> Unit
+                }
+            } catch (t: Throwable) {
+                Log.e(TAG, "Vote write failed for id=$messageId", t)
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "VoteReceiver"
+        const val ACTION_VOTE = "com.meatsack.motivator.ACTION_VOTE"
+        const val EXTRA_VOTE_UP = "vote_up"
+        const val EXTRA_NOTIFICATION_ID = "notification_id"
+
+        /**
+         * Unique request code per (message, direction). FLAG_IMMUTABLE PendingIntents
+         * with identical request codes would otherwise alias and reuse stale extras.
+         */
+        fun requestCode(messageId: Long, isUp: Boolean): Int =
+            (messageId.toInt() shl 1) or (if (isUp) 1 else 0)
+    }
+}
+```
+
+- [ ] **Step 1.4: Run the tests, expecting pass**
+
+Run: `./gradlew :wear:testDebugUnitTest --tests "com.meatsack.motivator.notification.VoteReceiverTest"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt \
+        wear/src/test/java/com/meatsack/motivator/notification/VoteReceiverTest.kt
+git commit -m "feat(wear): VoteReceiver with testable vote contract"
+```
+
+---
+
+## Task 2: Register `VoteReceiver` in the manifest
+
+**Files:**
+- Modify: `wear/src/main/AndroidManifest.xml`
+
+- [ ] **Step 2.1: Add the receiver**
+
+In `wear/src/main/AndroidManifest.xml`, inside `<application>` (after the
+`WatchSettingsReceiver` `<service>` block, before `</application>`), add:
+
+```xml
+        <receiver
+            android:name=".notification.VoteReceiver"
+            android:exported="false" />
+```
+
+- [ ] **Step 2.2: Build to verify the manifest parses**
+
+Run: `./gradlew :wear:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add wear/src/main/AndroidManifest.xml
+git commit -m "feat(wear): register VoteReceiver"
+```
+
+---
+
+## Task 3: Vote-action vector drawables
+
+**Files:**
+- Create: `wear/src/main/res/drawable/ic_thumb_up.xml`
+- Create: `wear/src/main/res/drawable/ic_thumb_down.xml`
+
+- [ ] **Step 3.1: Create `ic_thumb_up.xml`**
+
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,21h4V9H1V21zM23,10c0,-1.1,-0.9,-2,-2,-2h-6.31l0.95,-4.57 0.03,-0.32c0,-0.41,-0.17,-0.79,-0.44,-1.06L14.17,1 7.59,7.59C7.22,7.95 7,8.45 7,9v10c0,1.1 0.9,2 2,2h9c0.83,0 1.54,-0.5 1.84,-1.22l3.02,-7.05c0.09,-0.23 0.14,-0.47 0.14,-0.73v-2z" />
+</vector>
+```
+
+- [ ] **Step 3.2: Create `ic_thumb_down.xml`**
+
+```xml
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15,3H6c-0.83,0 -1.54,0.5 -1.84,1.22l-3.02,7.05C1.05,11.5 1,11.74 1,12v2c0,1.1 0.9,2 2,2h6.31l-0.95,4.57 -0.03,0.32c0,0.41 0.17,0.79 0.44,1.06L9.83,23l6.59,-6.59C16.78,16.05 17,15.55 17,15V5c0,-1.1 -0.9,-2 -2,-2zM19,3v12h4V3h-4z" />
+</vector>
+```
+
+- [ ] **Step 3.3: Build to verify resources compile**
+
+Run: `./gradlew :wear:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add wear/src/main/res/drawable/ic_thumb_up.xml wear/src/main/res/drawable/ic_thumb_down.xml
+git commit -m "feat(wear): thumb up/down vector icons for vote actions"
+```
+
+---
+
+## Task 4: Rework `InsultNotificationService` — notification with vote actions, no FSI
+
+**Files:**
+- Modify: `wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt`
+
+- [ ] **Step 4.1: Replace the imports and `showFullScreenNotification`**
+
+Replace the entire file contents of
+`wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt`
+with:
+
+```kotlin
+package com.meatsack.motivator.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.meatsack.motivator.R
+import com.meatsack.motivator.presentation.InsultActivity
+import com.meatsack.shared.model.Message
+
+class InsultNotificationService(private val context: Context) {
+
+    companion object {
+        const val CHANNEL_ID = "meatsack_insults"
+        const val EXTRA_MESSAGE_ID = "message_id"
+        const val EXTRA_MESSAGE_TEXT = "message_text"
+        const val EXTRA_STATS_TEXT = "stats_text"
+
+        // Each insult is its own notification (id = message.id) and auto-expires so
+        // the stream can't grow unbounded.
+        private const val NOTIFICATION_TIMEOUT_MS = 30L * 60L * 1000L
+    }
+
+    init {
+        createNotificationChannel()
+    }
+
+    fun deliverInsult(message: Message, statsText: String) {
+        vibrate()
+        showInsultNotification(message, statsText)
+    }
+
+    private fun vibrate() {
+        val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val manager = context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+            manager.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        }
+
+        val effect = VibrationEffect.createOneShot(500, VibrationEffect.DEFAULT_AMPLITUDE)
+        vibrator.vibrate(effect)
+    }
+
+    private fun showInsultNotification(message: Message, statsText: String) {
+        val notifId = message.id.toInt()
+
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            notifId,
+            Intent(context, InsultActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                putExtra(EXTRA_MESSAGE_ID, message.id)
+                putExtra(EXTRA_MESSAGE_TEXT, message.text)
+                putExtra(EXTRA_STATS_TEXT, statsText)
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_dialog_alert)
+            .setContentTitle(message.text)
+            .setContentText(statsText)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message.text))
+            .setPriority(NotificationCompat.PRIORITY_MAX)
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .setContentIntent(contentIntent)
+            .setAutoCancel(true)
+            .setTimeoutAfter(NOTIFICATION_TIMEOUT_MS)
+            .addAction(R.drawable.ic_thumb_down, "👎", votePendingIntent(message.id, notifId, isUp = false))
+            .addAction(R.drawable.ic_thumb_up, "👍", votePendingIntent(message.id, notifId, isUp = true))
+            .build()
+
+        NotificationManagerCompat.from(context).notify(notifId, notification)
+    }
+
+    private fun votePendingIntent(messageId: Long, notifId: Int, isUp: Boolean): PendingIntent {
+        val intent = Intent(context, VoteReceiver::class.java).apply {
+            action = VoteReceiver.ACTION_VOTE
+            putExtra(EXTRA_MESSAGE_ID, messageId)
+            putExtra(VoteReceiver.EXTRA_VOTE_UP, isUp)
+            putExtra(VoteReceiver.EXTRA_NOTIFICATION_ID, notifId)
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            VoteReceiver.requestCode(messageId, isUp),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Insult Notifications",
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = "Aggressive motivational messages"
+            enableVibration(false)
+        }
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.createNotificationChannel(channel)
+    }
+}
+```
+
+Notes:
+- `NOTIFICATION_ID` (the old constant `1`) is intentionally gone — id is now per-message.
+- `EXTRA_MESSAGE_ID/TEXT/STATS` keys are unchanged, so `InsultActivity` and the debug
+  activity keep working.
+
+- [ ] **Step 4.2: Build**
+
+Run: `./gradlew :wear:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4.3: Run the full wear unit suite (no regressions)**
+
+Run: `./gradlew :wear:testDebugUnitTest`
+Expected: PASS (includes `VoteReceiverTest`).
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
+git commit -m "feat(wear): deliver insults as votable notifications, drop full-screen intent"
+```
+
+---
+
+## Task 5: Manifest cleanup — remove FSI permission and activity flags
+
+**Files:**
+- Modify: `wear/src/main/AndroidManifest.xml`
+
+- [ ] **Step 5.1: Remove the FSI permission**
+
+Delete this line from `wear/src/main/AndroidManifest.xml`:
+
+```xml
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+```
+
+- [ ] **Step 5.2: Remove the FSI-only activity flags**
+
+Change the `InsultActivity` declaration from:
+
+```xml
+        <activity
+            android:name=".presentation.InsultActivity"
+            android:exported="false"
+            android:showOnLockScreen="true"
+            android:turnScreenOn="true"
+            android:taskAffinity=""
+            android:excludeFromRecents="true" />
+```
+
+to:
+
+```xml
+        <activity
+            android:name=".presentation.InsultActivity"
+            android:exported="false"
+            android:taskAffinity=""
+            android:excludeFromRecents="true" />
+```
+
+- [ ] **Step 5.3: Verify the merged release manifest has no FSI permission**
+
+Run: `./gradlew :wear:processReleaseManifest` then inspect the merged manifest:
+`grep -c "USE_FULL_SCREEN_INTENT" wear/build/intermediates/merged_manifest/release/AndroidManifest.xml`
+Expected: `0` (or "file/match not found"). Also confirm `TestFireActivity` is absent:
+`grep -c "TestFireActivity" wear/build/intermediates/merged_manifest/release/AndroidManifest.xml`
+Expected: `0`.
+
+(If the release manifest task name differs in this AGP version, use
+`./gradlew :wear:assembleRelease` and inspect under `wear/build/intermediates/merged_manifest/release/`.)
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add wear/src/main/AndroidManifest.xml
+git commit -m "chore(wear): remove USE_FULL_SCREEN_INTENT and FSI activity flags for Play compliance"
+```
+
+---
+
+## Task 6: Repurpose `TestFireActivity` to fire the real notification
+
+The existing debug-only `TestFireActivity` launches `InsultActivity` directly (old
+full-screen path). Repoint it at the new notification path so the on-device test
+exercises what users actually get, with a real votable message id.
+
+**Files:**
+- Modify: `wear/src/debug/java/com/meatsack/motivator/debug/TestFireActivity.kt`
+
+- [ ] **Step 6.1: Replace the file**
+
+Replace the entire contents of
+`wear/src/debug/java/com/meatsack/motivator/debug/TestFireActivity.kt` with:
+
+```kotlin
+package com.meatsack.motivator.debug
+
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import com.meatsack.motivator.MeatsackWearApp
+import com.meatsack.motivator.notification.InsultNotificationService
+import com.meatsack.shared.constants.EscalationLevel
+import com.meatsack.shared.constants.MessageSource
+import com.meatsack.shared.constants.MessageTone
+import com.meatsack.shared.constants.TriggerType
+import com.meatsack.shared.db.AppDatabase
+import com.meatsack.shared.model.Message
+import kotlinx.coroutines.launch
+
+/**
+ * Debug-only. Fires a REAL insult notification (the production delivery path) so the
+ * notification + 👎/👍 voting + wrist-raise surfacing can be verified on-device:
+ *
+ *   adb shell am start -n com.meatsack.motivator/.debug.TestFireActivity
+ *
+ * Picks the top message from the DB so the vote lands on a real row; falls back to a
+ * throwaway message (id = -1, vote is a no-op) if the DB is empty.
+ */
+class TestFireActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val stats = intent.getStringExtra("stats") ?: "42 steps. TEST fire."
+        val fallbackText = intent.getStringExtra("text")
+            ?: "GET UP, you cloud-native pile of laundry."
+
+        val app = application as MeatsackWearApp
+        val notifier = InsultNotificationService(applicationContext)
+
+        app.applicationScope.launch {
+            val message = AppDatabase.getDatabase(applicationContext)
+                .messageDao()
+                .getAllMessages()
+                .firstOrNull()
+                ?: Message(
+                    text = fallbackText,
+                    level = EscalationLevel.AGGRESSIVE,
+                    triggerType = TriggerType.INACTIVITY,
+                    tone = MessageTone.FULL_SEND,
+                    source = MessageSource.PRE_WRITTEN,
+                )
+            Log.d("TestFireActivity", "Firing test insult notification: ${message.text}")
+            notifier.deliverInsult(message, stats)
+        }
+
+        finish()
+    }
+}
+```
+
+- [ ] **Step 6.2: Build the debug variant**
+
+Run: `./gradlew :wear:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add wear/src/debug/java/com/meatsack/motivator/debug/TestFireActivity.kt
+git commit -m "test(wear): debug TestFireActivity fires the real vote notification"
+```
+
+---
+
+## Task 7: Full build, unit sweep, and on-device verification
+
+**Files:** none modified.
+
+- [ ] **Step 7.1: Full build (catches spotless/lint regressions)**
+
+Run: `./gradlew build`
+Expected: BUILD SUCCESSFUL. If spotless fails: `./gradlew spotlessApply && git add -u && git commit -m "style: spotless"`.
+
+- [ ] **Step 7.2: Full wear unit suite**
+
+Run: `./gradlew :wear:testDebugUnitTest`
+Expected: all green, including `VoteReceiverTest`.
+
+- [ ] **Step 7.3: Install the debug build on the watch**
+
+```bash
+./gradlew :wear:assembleDebug
+adb -s <watch-id> install -r wear/build/outputs/apk/debug/wear-debug.apk
+```
+
+(`<watch-id>` is the current `adb devices` entry for the watch, e.g. `192.168.1.109:<port>`.)
+
+- [ ] **Step 7.4: Fire the real notification and verify the flow**
+
+```bash
+adb -s <watch-id> shell am start -n com.meatsack.motivator/.debug.TestFireActivity
+```
+
+Verify on the watch:
+1. It **vibrates** and the insult **peeks / appears** in the notification stream.
+2. **Raise your wrist** → the notification surfaces filling the screen with the insult
+   text and **👎 / 👍** buttons.
+3. **Tap 👍** → the notification dismisses. Confirm the DB write in logcat:
+   `adb -s <watch-id> logcat -d | grep -iE "VoteReceiver|Vote write"` (no error logged).
+4. Fire again, then **tap the notification body** → `InsultActivity` opens (centered
+   insult + buttons) → tapping a button votes and closes.
+
+- [ ] **Step 7.5: Confirm the appop is no longer needed**
+
+The app no longer declares `USE_FULL_SCREEN_INTENT`. Confirm voting takes over via
+the notification **without** any FSI grant:
+`adb -s <watch-id> shell cmd appops get com.meatsack.motivator USE_FULL_SCREEN_INTENT`
+Expected: the value is irrelevant to behavior now (permission not declared). The
+notification + vote flow in 7.4 must work regardless.
+
+- [ ] **Step 7.6: Push the branch**
+
+```bash
+git push -u origin feature/play-compliant-vote-notifications
+```
+
+- [ ] **Step 7.7: Open the PR**
+
+```bash
+gh pr create --title "Play-compliant vote notifications (drop full-screen intent)" --body "$(cat <<'EOF'
+## Summary
+- Insults are now delivered as HIGH-importance notifications with inline 👎/👍 action buttons, handled by a new `VoteReceiver`. Voting works directly on the notification — read & vote on wrist-raise, no screen takeover.
+- Removed all full-screen-intent machinery (`setFullScreenIntent`, `USE_FULL_SCREEN_INTENT` permission, `showOnLockScreen`/`turnScreenOn`) — the Play-restricted path that was being demoted on Android 14+.
+- Each insult is its own notification (`id = message.id`), auto-expiring after 30 min; tapping the body still opens the centered `InsultActivity`.
+- Debug-only `TestFireActivity` now fires the real notification for on-device verification.
+
+## Why
+On Android 14+, `USE_FULL_SCREEN_INTENT` is denied-by-default for non-alarm apps, so the voting takeover was demoted to a silent stream entry whenever the watch screen was on. That permission is also Play-restricted. Notification actions are the Play-safe, idiomatic Wear pattern.
+
+Spec: `docs/superpowers/specs/2026-06-07-play-compliant-vote-notification-design.md`
+
+## Test plan
+- [x] `./gradlew build` — BUILD SUCCESSFUL
+- [x] `./gradlew :wear:testDebugUnitTest` — green (incl. new `VoteReceiverTest`)
+- [x] On-device: `am start .debug.TestFireActivity` → notification surfaces on raise → 👍/👎 vote records + dismisses → tap body opens `InsultActivity`
+- [x] Merged release manifest contains no `USE_FULL_SCREEN_INTENT` / `TestFireActivity`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7.8: Run PR review per project convention**
+
+After `gh pr create`, invoke `pr-review-toolkit:review-pr` on the new PR (per the
+repo's memory/CLAUDE conventions). This PR is small (~7 files); a single
+code-reviewer pass is sufficient.
+
+---
+
+## Testing note — why no `Notification`-builder unit test
+
+The spec floated asserting the built notification's shape (2 actions, no
+`fullScreenIntent`, timeout set). Doing that in a JVM unit test needs Robolectric,
+which is **not** a current dependency — adding it is out of proportion for this
+change. Instead: the **pure `requestCode`/`VoteAction` logic is unit-tested** (Task 1,
+the part with real branching), and the **assembled notification is verified on-device**
+(Task 7.4) plus the **merged-manifest check** confirms no FSI (Task 5.3). This trades
+one brittle, dependency-heavy unit test for direct runtime evidence.
+
+## Risks / known unknowns
+
+- **Wrist-raise surfacing of an app-local HIGH notification** is expected to match
+  bridged messaging notifications (same importance tier, confirmed enabled on the
+  device) but was not provable pre-build; Step 7.4 is the definitive check.
+- **`message.id.toInt()`** assumes ids fit `Int` (true for this app's autoincrement
+  range). Documented in the spec.
+- **Notification action rendering on Wear**: titles use emoji + thumb vector icons;
+  if the watch renders only icons, the thumbs still disambiguate.
+
+## Out of scope (tracked separately)
+
+- Vote back-sync watch → phone (existing v1 limitation).
+- The BehindPace/EndOfDay worker self-cancel concern (REPLACE-while-running) — needs
+  its own systematic-debugging pass and spec.

--- a/docs/superpowers/specs/2026-06-07-play-compliant-vote-notification-design.md
+++ b/docs/superpowers/specs/2026-06-07-play-compliant-vote-notification-design.md
@@ -1,0 +1,180 @@
+# Play-Compliant Vote Notification — Design
+
+**Date:** 2026-06-07
+**Status:** Approved (brainstorming) — pending implementation plan
+**Branch:** `feature/play-compliant-vote-notifications`
+
+## Problem
+
+On the watch, most insults fire but never present the 👍/👎 voting UI — they only
+vibrate and sit in the notification stream. Some (long-idle "2-hour" insults) do
+take over the screen.
+
+### Root cause (confirmed)
+
+The voting UI is delivered **exclusively** via `setFullScreenIntent` (FSI). On
+Android 14+ the `USE_FULL_SCREEN_INTENT` permission is denied-by-default for
+non-alarm/non-calling apps, so the OS **demotes the FSI to a heads-up notification
+whenever the watch screen is on**, and only launches the full-screen activity when
+the screen is off/locked. The real Galaxy Watch runs Android 16 (API 36); the FSI
+code is unchanged since v1, so this is an OS-behavior expression, not a code
+regression. (Evidence: appop `USE_FULL_SCREEN_INTENT: default` with a recent
+`rejectTime`; single FSI-only delivery path in `InsultNotificationService`.)
+
+### Why a redesign, not a permission grant
+
+The app is targeted for the **Google Play Store**. `USE_FULL_SCREEN_INTENT` is a
+Play-restricted permission (alarms/calling only); declaring it risks rejection.
+Forcing a full-screen activity from the background on a timer/inactivity is exactly
+what Play's disruptive-behavior policy prohibits, regardless of mechanism
+(`SYSTEM_ALERT_WINDOW` included). The Play-safe model is **notification action
+buttons**: vote directly on the notification, no screen takeover, no restricted
+permission.
+
+## Goals
+
+- Every insult is **votable** (👍/👎) directly from the notification — Play-compliant.
+- Reproduce the desired "WhatsApp-style" experience: the insult **peeks** onto the
+  watch face when it fires and the notification **fills the screen with the vote
+  buttons when the user raises their wrist** (this is the OS surfacing a
+  HIGH-importance notification — not an app screen takeover).
+- Keep the full-screen `InsultActivity` (centered insult + buttons) as an **optional
+  tap-to-open** view, reached via a normal `contentIntent` (no special permission).
+- Remove all FSI machinery so there is no restricted permission and no grant to lose
+  on reinstall.
+- Add a **debug-only fire trigger** so the behavior can be verified on-device on
+  demand, now and in future.
+
+## Non-goals / out of scope
+
+- Back-syncing votes from watch → phone (existing v1 limitation; unchanged).
+- Centering text **in the notification** (system-styled, not controllable on Wear).
+  Centering remains in the tap-to-open `InsultActivity` only.
+- The separate **worker self-cancel** concern (BehindPace/EndOfDay re-enqueue with
+  `ExistingWorkPolicy.REPLACE` at the top of `doWork`, which may cancel the running
+  instance before `deliverInsult`). Flagged for a separate investigation/spec.
+- Forcing notification surfacing when the user's watch settings (DND, Bedtime,
+  notification pop-ups) suppress it — that is user/OS configuration.
+
+## Approach (chosen)
+
+Vote taps are handled by a lightweight **`BroadcastReceiver`** (no UI, no activity
+flash). Each vote button is a broadcast `PendingIntent`; the receiver records the
+vote on the existing `applicationScope` and cancels the notification. The
+full-screen `InsultActivity` stays, reached by tapping the notification body, and
+writes votes through the **same** `MessageRepository` — one source of truth for vote
+writes.
+
+Rejected alternatives: invisible/translucent Activity (flicker, heavier); Service
+(foreground-service ceremony for a trivial DB increment).
+
+## Components
+
+### New
+
+| Component | Location | Responsibility |
+|---|---|---|
+| `VoteReceiver : BroadcastReceiver` | `wear/.../notification/` (`exported="false"`) | Handle vote actions. Read `messageId` + direction + notification id; `goAsync()`; record vote via `MessageRepository` on `applicationScope`; cancel the notification; `finish()`. |
+| `DebugFireReceiver : BroadcastReceiver` | `wear/src/debug/.../` (debug source set only, `exported="true"`) | On `com.meatsack.motivator.DEBUG_FIRE_INSULT`, select a real message and call `deliverInsult(...)`. Compiled into debug builds only; physically absent from release. |
+
+### Modified
+
+- **`InsultNotificationService`** — `showFullScreenNotification` → `showInsultNotification`:
+  - **Remove** `setFullScreenIntent(...)`.
+  - Add two `NotificationCompat.Action` (👎/👍) → broadcast `PendingIntent`s to
+    `VoteReceiver` carrying `EXTRA_MESSAGE_ID`, a vote-direction extra, and the
+    notification id.
+  - Add `contentIntent` → `InsultActivity` (plain tap-to-open).
+  - `setContentTitle(insult)` + `setStyle(BigTextStyle().bigText(insult))` so the
+    full insult is readable when the notification surfaces on raise (single-line
+    titles truncate; the #38 100-char cap keeps it bounded). Stats line as
+    `setContentText(stats)`.
+  - `setTimeoutAfter(30 * 60 * 1000L)`, keep `setAutoCancel(true)`.
+  - Notification id = `message.id.toInt()` (identical re-fires dedupe; distinct
+    insults stack and each is independently votable).
+  - Keep `vibrate()`; keep channel importance `HIGH`; change
+    `CATEGORY_ALARM` → `CATEGORY_REMINDER`.
+- **`presentation/MainActivity`** — also request `POST_NOTIFICATIONS` at runtime
+  (Android 13+) alongside the existing `ACTIVITY_RECOGNITION` request, so
+  notifications appear on fresh installs.
+- **`wear/src/main/AndroidManifest.xml`**:
+  - Remove `<uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />`.
+  - Remove `android:showOnLockScreen` and `android:turnScreenOn` from `InsultActivity`
+    (only needed for the FSI takeover).
+  - Register `VoteReceiver` (`exported="false"`).
+
+### Unchanged
+
+- `InsultActivity` + `InsultScreen` (still the tap-to-open full view; `InsultScreen`
+  already centers text). Votes flow through `MessageRepository`.
+- `MessageRepository`, `MessageDao`, `Message` schema, the 3-downvote retirement.
+- Trigger sources (inactivity poll, BehindPace/EndOfDay workers).
+
+## Data flow
+
+1. **Trigger** (inactivity poll / behind-pace / end-of-day worker / debug broadcast)
+   → `MessageRepository.selectMessage(...)` → `InsultNotificationService.deliverInsult(message, stats)`.
+2. `deliverInsult` → `vibrate()` + `showInsultNotification(message, stats)`.
+3. `showInsultNotification` builds a HIGH-importance notification: title = insult,
+   body = stats, two vote actions, `contentIntent` → `InsultActivity`,
+   `setTimeoutAfter(30 min)`, `setAutoCancel(true)`, id = `message.id.toInt()`; posts
+   via `NotificationManagerCompat.notify(...)`.
+4. **On the watch:** it vibrates and peeks onto the watch face. Raising the wrist
+   surfaces the notification (HIGH importance) filling the screen with the insult +
+   👎/👍 — the WhatsApp-style read-and-vote-on-raise experience.
+5a. **Tap 👎/👍** → `VoteReceiver.onReceive` → `goAsync()` →
+    `applicationScope.launch { repo.voteUp/voteDown(messageId) }` →
+    `NotificationManagerCompat.cancel(notifId)` → `pendingResult.finish()`.
+5b. **Tap card body** → `InsultActivity` opens (centered) → votes through the same
+    `MessageRepository`; `autoCancel` clears the notification.
+6. **Untouched** → notification self-dismisses after 30 minutes.
+
+## Error handling & edge cases
+
+- **Invalid/missing `messageId`** (≤ 0) in `VoteReceiver` → no-op, still `finish()`
+  (mirrors `InsultActivity.recordVote` guard).
+- **DB write failure** → wrapped in try/catch, logged at ERROR, does not crash. The
+  notification is cancelled after the attempt (success or failure) so the user's tap
+  is acknowledged. `pendingResult.finish()` runs in `finally`.
+- **`goAsync()` window** (~10 s) is ample for a single increment.
+- **Notification id collision** — `message.id.toInt()`: `Message.id` is an
+  auto-generated `Long`, in practice small; documented assumption that it fits `Int`.
+  Identical message re-fire replaces its own prior notification (acceptable dedupe).
+- **PendingIntent request codes** must be unique per (message, direction) under
+  `FLAG_IMMUTABLE` to avoid stale-extra reuse; encode messageId + direction into the
+  request code; `contentIntent` gets its own. Use `FLAG_IMMUTABLE | FLAG_UPDATE_CURRENT`.
+- **`POST_NOTIFICATIONS` denied** (Android 13+) → notifications silently don't show;
+  `MainActivity` requests it. If denied, that's the user's choice (no forced
+  re-prompt this iteration).
+- **Debug-fire with empty DB** → log and no-op.
+
+## Testing
+
+### Unit (JVM, no device)
+
+- Extract a **pure parsing function** + a `VoteSink` interface for `VoteReceiver`
+  (mirroring `WatchSettingsReceiver.applySnapshot`/`ApplySink`), so we test without an
+  Android runtime:
+  - up action → `sink.voteUp(id)`; down action → `sink.voteDown(id)`.
+  - missing/invalid id → no sink call.
+- Extract notification configuration into a testable data holder consumed by the
+  builder; assert: exactly 2 vote actions present, **no** `fullScreenIntent`,
+  `timeoutAfter` set, `contentIntent` present, correct extras/request codes.
+- Existing `MessageRepository`/`MessageSerializer` tests remain green.
+
+### On-device (debug-fire trigger)
+
+`adb shell am broadcast -a com.meatsack.motivator.DEBUG_FIRE_INSULT` →
+1. real HIGH notification fires → raise wrist → confirm it surfaces with 👎/👍;
+2. tap a vote → confirm DB increment (logcat) + notification dismissed;
+3. tap body → `InsultActivity` opens (centered) → vote works;
+4. confirm the **merged release manifest** contains no `USE_FULL_SCREEN_INTENT` and
+   no `DebugFireReceiver`.
+
+## Play-compliance checklist
+
+- [ ] No `USE_FULL_SCREEN_INTENT` permission in the release manifest.
+- [ ] No `setFullScreenIntent(...)` in code.
+- [ ] `DebugFireReceiver` present only in the `debug` source set.
+- [ ] Notification category `REMINDER` (not `ALARM`).
+- [ ] `POST_NOTIFICATIONS` requested at runtime.

--- a/wear/src/debug/java/com/meatsack/motivator/debug/TestFireActivity.kt
+++ b/wear/src/debug/java/com/meatsack/motivator/debug/TestFireActivity.kt
@@ -1,46 +1,54 @@
 package com.meatsack.motivator.debug
 
-import android.content.Intent
-import android.os.Build
 import android.os.Bundle
-import android.os.VibrationEffect
-import android.os.Vibrator
-import android.os.VibratorManager
 import android.util.Log
 import androidx.activity.ComponentActivity
+import com.meatsack.motivator.MeatsackWearApp
 import com.meatsack.motivator.notification.InsultNotificationService
-import com.meatsack.motivator.presentation.InsultActivity
+import com.meatsack.shared.constants.EscalationLevel
+import com.meatsack.shared.constants.MessageSource
+import com.meatsack.shared.constants.MessageTone
+import com.meatsack.shared.constants.TriggerType
+import com.meatsack.shared.db.AppDatabase
+import com.meatsack.shared.model.Message
+import kotlinx.coroutines.launch
 
+/**
+ * Debug-only. Fires a REAL insult notification (the production delivery path) so the
+ * notification + 👎/👍 voting + wrist-raise surfacing can be verified on-device:
+ *
+ *   adb shell am start -n com.meatsack.motivator/.debug.TestFireActivity
+ *
+ * Picks the top message from the DB so the vote lands on a real row; falls back to a
+ * throwaway message (id = -1, vote is a no-op) if the DB is empty.
+ */
 class TestFireActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val text = intent.getStringExtra("text")
-            ?: "GET UP, you cloud-native pile of laundry."
         val stats = intent.getStringExtra("stats") ?: "42 steps. TEST fire."
+        val fallbackText = intent.getStringExtra("text")
+            ?: "GET UP, you cloud-native pile of laundry."
 
-        Log.d("TestFireActivity", "Forwarding to InsultActivity: $text")
+        val app = application as MeatsackWearApp
+        val notifier = InsultNotificationService(applicationContext)
 
-        vibrate()
-
-        startActivity(
-            Intent(this, InsultActivity::class.java).apply {
-                putExtra(InsultNotificationService.EXTRA_MESSAGE_ID, -1L)
-                putExtra(InsultNotificationService.EXTRA_MESSAGE_TEXT, text)
-                putExtra(InsultNotificationService.EXTRA_STATS_TEXT, stats)
-            },
-        )
-        finish()
-    }
-
-    private fun vibrate() {
-        val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val manager = getSystemService(VIBRATOR_MANAGER_SERVICE) as VibratorManager
-            manager.defaultVibrator
-        } else {
-            @Suppress("DEPRECATION")
-            getSystemService(VIBRATOR_SERVICE) as Vibrator
+        app.applicationScope.launch {
+            val message = AppDatabase.getDatabase(applicationContext)
+                .messageDao()
+                .getAllMessages()
+                .firstOrNull()
+                ?: Message(
+                    text = fallbackText,
+                    level = EscalationLevel.AGGRESSIVE,
+                    triggerType = TriggerType.INACTIVITY,
+                    tone = MessageTone.FULL_SEND,
+                    source = MessageSource.PRE_WRITTEN,
+                )
+            Log.d("TestFireActivity", "Firing test insult notification: ${message.text}")
+            notifier.deliverInsult(message, stats)
         }
-        vibrator.vibrate(VibrationEffect.createOneShot(500, VibrationEffect.DEFAULT_AMPLITUDE))
+
+        finish()
     }
 }

--- a/wear/src/debug/java/com/meatsack/motivator/debug/TestFireActivity.kt
+++ b/wear/src/debug/java/com/meatsack/motivator/debug/TestFireActivity.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
  *   adb shell am start -n com.meatsack.motivator/.debug.TestFireActivity
  *
  * Picks the top message from the DB so the vote lands on a real row; falls back to a
- * throwaway message (id = -1, vote is a no-op) if the DB is empty.
+ * throwaway message (default id = 0, vote is a no-op) if the DB is empty.
  */
 class TestFireActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -80,6 +80,10 @@
             </intent-filter>
         </service>
 
+        <receiver
+            android:name=".notification.VoteReceiver"
+            android:exported="false" />
+
     </application>
 
 </manifest>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -46,8 +45,6 @@
         <activity
             android:name=".presentation.InsultActivity"
             android:exported="false"
-            android:showOnLockScreen="true"
-            android:turnScreenOn="true"
             android:taskAffinity=""
             android:excludeFromRecents="true" />
 

--- a/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
@@ -26,6 +26,8 @@ class InsultNotificationService(private val context: Context) {
         // Each insult is its own notification (id = message.id) and auto-expires so
         // the stream can't grow unbounded.
         private const val NOTIFICATION_TIMEOUT_MS = 30L * 60L * 1000L
+
+        const val INSULT_TAG = "insult"
     }
 
     init {
@@ -83,7 +85,7 @@ class InsultNotificationService(private val context: Context) {
             .addAction(R.drawable.ic_thumb_up, "👍", votePendingIntent(message.id, notifId, isUp = true))
             .build()
 
-        NotificationManagerCompat.from(context).notify(notifId, notification)
+        NotificationManagerCompat.from(context).notify(INSULT_TAG, notifId, notification)
     }
 
     private fun votePendingIntent(messageId: Long, notifId: Int, isUp: Boolean): PendingIntent {

--- a/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
@@ -1,16 +1,20 @@
 package com.meatsack.motivator.notification
 
+import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import com.meatsack.motivator.R
 import com.meatsack.motivator.presentation.InsultActivity
 import com.meatsack.shared.model.Message
@@ -18,6 +22,7 @@ import com.meatsack.shared.model.Message
 class InsultNotificationService(private val context: Context) {
 
     companion object {
+        private const val TAG = "InsultNotification"
         const val CHANNEL_ID = "meatsack_insults"
         const val EXTRA_MESSAGE_ID = "message_id"
         const val EXTRA_MESSAGE_TEXT = "message_text"
@@ -53,6 +58,15 @@ class InsultNotificationService(private val context: Context) {
     }
 
     private fun showInsultNotification(message: Message, statsText: String) {
+        // POST_NOTIFICATIONS is requested at runtime in MainActivity; if the user
+        // denied it, posting would be a silent OS-level drop. Make that explicit.
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.w(TAG, "POST_NOTIFICATIONS denied; skipping insult notification for id=${message.id}")
+            return
+        }
+
         val notifId = message.id.toInt()
 
         val contentIntent = PendingIntent.getActivity(

--- a/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
@@ -10,6 +10,8 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.meatsack.motivator.R
 import com.meatsack.motivator.presentation.InsultActivity
 import com.meatsack.shared.model.Message
 
@@ -17,10 +19,13 @@ class InsultNotificationService(private val context: Context) {
 
     companion object {
         const val CHANNEL_ID = "meatsack_insults"
-        const val NOTIFICATION_ID = 1
         const val EXTRA_MESSAGE_ID = "message_id"
         const val EXTRA_MESSAGE_TEXT = "message_text"
         const val EXTRA_STATS_TEXT = "stats_text"
+
+        // Each insult is its own notification (id = message.id) and auto-expires so
+        // the stream can't grow unbounded.
+        private const val NOTIFICATION_TIMEOUT_MS = 30L * 60L * 1000L
     }
 
     init {
@@ -29,7 +34,7 @@ class InsultNotificationService(private val context: Context) {
 
     fun deliverInsult(message: Message, statsText: String) {
         vibrate()
-        showFullScreenNotification(message, statsText)
+        showInsultNotification(message, statsText)
     }
 
     private fun vibrate() {
@@ -45,34 +50,51 @@ class InsultNotificationService(private val context: Context) {
         vibrator.vibrate(effect)
     }
 
-    private fun showFullScreenNotification(message: Message, statsText: String) {
-        val intent = Intent(context, InsultActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            putExtra(EXTRA_MESSAGE_ID, message.id)
-            putExtra(EXTRA_MESSAGE_TEXT, message.text)
-            putExtra(EXTRA_STATS_TEXT, statsText)
-        }
+    private fun showInsultNotification(message: Message, statsText: String) {
+        val notifId = message.id.toInt()
 
-        val pendingIntent = PendingIntent.getActivity(
+        val contentIntent = PendingIntent.getActivity(
             context,
-            0,
-            intent,
+            notifId,
+            Intent(context, InsultActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                putExtra(EXTRA_MESSAGE_ID, message.id)
+                putExtra(EXTRA_MESSAGE_TEXT, message.text)
+                putExtra(EXTRA_STATS_TEXT, statsText)
+            },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
 
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_dialog_alert)
-            .setContentTitle("meatsackMotivator")
-            .setContentText(message.text)
+            .setContentTitle(message.text)
+            .setContentText(statsText)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message.text))
             .setPriority(NotificationCompat.PRIORITY_MAX)
-            .setCategory(NotificationCompat.CATEGORY_ALARM)
-            .setFullScreenIntent(pendingIntent, true)
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .setContentIntent(contentIntent)
             .setAutoCancel(true)
+            .setTimeoutAfter(NOTIFICATION_TIMEOUT_MS)
+            .addAction(R.drawable.ic_thumb_down, "👎", votePendingIntent(message.id, notifId, isUp = false))
+            .addAction(R.drawable.ic_thumb_up, "👍", votePendingIntent(message.id, notifId, isUp = true))
             .build()
 
-        val notificationManager =
-            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(NOTIFICATION_ID, notification)
+        NotificationManagerCompat.from(context).notify(notifId, notification)
+    }
+
+    private fun votePendingIntent(messageId: Long, notifId: Int, isUp: Boolean): PendingIntent {
+        val intent = Intent(context, VoteReceiver::class.java).apply {
+            action = VoteReceiver.ACTION_VOTE
+            putExtra(EXTRA_MESSAGE_ID, messageId)
+            putExtra(VoteReceiver.EXTRA_VOTE_UP, isUp)
+            putExtra(VoteReceiver.EXTRA_NOTIFICATION_ID, notifId)
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            VoteReceiver.requestCode(messageId, isUp),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
     }
 
     private fun createNotificationChannel() {

--- a/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
@@ -67,6 +67,8 @@ class InsultNotificationService(private val context: Context) {
             return
         }
 
+        // Assumes message.id fits in an Int (Room autoincrement ids stay well under 2^31);
+        // see VoteReceiver.requestCode for the same bounded-id assumption.
         val notifId = message.id.toInt()
 
         val contentIntent = PendingIntent.getActivity(

--- a/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/notification/InsultNotificationService.kt
@@ -69,7 +69,11 @@ class InsultNotificationService(private val context: Context) {
             .setSmallIcon(android.R.drawable.ic_dialog_alert)
             .setContentTitle(message.text)
             .setContentText(statsText)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(message.text))
+            .setStyle(
+                NotificationCompat.BigTextStyle()
+                    .bigText(message.text)
+                    .setSummaryText(statsText),
+            )
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setCategory(NotificationCompat.CATEGORY_REMINDER)
             .setContentIntent(contentIntent)

--- a/wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt
+++ b/wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt
@@ -71,6 +71,12 @@ class VoteReceiver : BroadcastReceiver() {
         /**
          * Unique request code per (message, direction). FLAG_IMMUTABLE PendingIntents
          * with identical request codes would otherwise alias and reuse stale extras.
+         *
+         * Assumes message ids fit in the low 31 bits (`messageId < 2^31`): `toInt() shl 1`
+         * keeps the low bit for direction and discards anything above bit 30. True for our
+         * Room autoincrement ids (the library is capped well under that). If ids ever become
+         * server-assigned 64-bit values, mix in the high bits or two messages sharing low
+         * bits would silently share a PendingIntent and misroute votes.
          */
         fun requestCode(messageId: Long, isUp: Boolean): Int =
             (messageId.toInt() shl 1) or (if (isUp) 1 else 0)

--- a/wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt
+++ b/wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt
@@ -1,0 +1,76 @@
+package com.meatsack.motivator.notification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationManagerCompat
+import com.meatsack.motivator.MeatsackWearApp
+import com.meatsack.motivator.messages.MessageRepository
+import com.meatsack.shared.db.AppDatabase
+import kotlinx.coroutines.launch
+
+/**
+ * Records a 👍/👎 vote tapped directly on an insult notification, then dismisses
+ * that notification. Runs on the app scope so the DB write outlives this receiver.
+ */
+class VoteReceiver : BroadcastReceiver() {
+
+    /** Pure result of interpreting a vote intent — unit-testable without Android. */
+    sealed class VoteAction {
+        data class Up(val messageId: Long) : VoteAction()
+        data class Down(val messageId: Long) : VoteAction()
+        object Ignore : VoteAction()
+
+        companion object {
+            fun from(messageId: Long, isUp: Boolean): VoteAction = when {
+                messageId <= 0L -> Ignore
+                isUp -> Up(messageId)
+                else -> Down(messageId)
+            }
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val messageId = intent.getLongExtra(InsultNotificationService.EXTRA_MESSAGE_ID, -1L)
+        val isUp = intent.getBooleanExtra(EXTRA_VOTE_UP, true)
+        val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+
+        // Acknowledge the tap immediately by dismissing the notification.
+        if (notifId > 0) NotificationManagerCompat.from(context).cancel(notifId)
+
+        val action = VoteAction.from(messageId, isUp)
+        if (action is VoteAction.Ignore) return
+
+        val app = context.applicationContext as MeatsackWearApp
+        val pending = goAsync()
+        app.applicationScope.launch {
+            try {
+                val repo = MessageRepository(AppDatabase.getDatabase(context).messageDao())
+                when (action) {
+                    is VoteAction.Up -> repo.voteUp(action.messageId)
+                    is VoteAction.Down -> repo.voteDown(action.messageId)
+                    VoteAction.Ignore -> Unit
+                }
+            } catch (t: Throwable) {
+                Log.e(TAG, "Vote write failed for id=$messageId", t)
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "VoteReceiver"
+        const val ACTION_VOTE = "com.meatsack.motivator.ACTION_VOTE"
+        const val EXTRA_VOTE_UP = "vote_up"
+        const val EXTRA_NOTIFICATION_ID = "notification_id"
+
+        /**
+         * Unique request code per (message, direction). FLAG_IMMUTABLE PendingIntents
+         * with identical request codes would otherwise alias and reuse stale extras.
+         */
+        fun requestCode(messageId: Long, isUp: Boolean): Int =
+            (messageId.toInt() shl 1) or (if (isUp) 1 else 0)
+    }
+}

--- a/wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt
+++ b/wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt
@@ -37,7 +37,9 @@ class VoteReceiver : BroadcastReceiver() {
         val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
 
         // Acknowledge the tap immediately by dismissing the notification.
-        if (notifId != -1) NotificationManagerCompat.from(context).cancel(notifId)
+        if (notifId != -1) {
+            NotificationManagerCompat.from(context).cancel(InsultNotificationService.INSULT_TAG, notifId)
+        }
 
         val action = VoteAction.from(messageId, isUp)
         if (action is VoteAction.Ignore) return

--- a/wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt
+++ b/wear/src/main/java/com/meatsack/motivator/notification/VoteReceiver.kt
@@ -37,7 +37,7 @@ class VoteReceiver : BroadcastReceiver() {
         val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
 
         // Acknowledge the tap immediately by dismissing the notification.
-        if (notifId > 0) NotificationManagerCompat.from(context).cancel(notifId)
+        if (notifId != -1) NotificationManagerCompat.from(context).cancel(notifId)
 
         val action = VoteAction.from(messageId, isUp)
         if (action is VoteAction.Ignore) return

--- a/wear/src/main/res/drawable/ic_thumb_down.xml
+++ b/wear/src/main/res/drawable/ic_thumb_down.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15,3H6c-0.83,0 -1.54,0.5 -1.84,1.22l-3.02,7.05C1.05,11.5 1,11.74 1,12v2c0,1.1 0.9,2 2,2h6.31l-0.95,4.57 -0.03,0.32c0,0.41 0.17,0.79 0.44,1.06L9.83,23l6.59,-6.59C16.78,16.05 17,15.55 17,15V5c0,-1.1 -0.9,-2 -2,-2zM19,3v12h4V3h-4z" />
+</vector>

--- a/wear/src/main/res/drawable/ic_thumb_up.xml
+++ b/wear/src/main/res/drawable/ic_thumb_up.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,21h4V9H1V21zM23,10c0,-1.1,-0.9,-2,-2,-2h-6.31l0.95,-4.57 0.03,-0.32c0,-0.41,-0.17,-0.79,-0.44,-1.06L14.17,1 7.59,7.59C7.22,7.95 7,8.45 7,9v10c0,1.1 0.9,2 2,2h9c0.83,0 1.54,-0.5 1.84,-1.22l3.02,-7.05c0.09,-0.23 0.14,-0.47 0.14,-0.73v-2z" />
+</vector>

--- a/wear/src/test/java/com/meatsack/motivator/notification/VoteReceiverTest.kt
+++ b/wear/src/test/java/com/meatsack/motivator/notification/VoteReceiverTest.kt
@@ -1,0 +1,40 @@
+package com.meatsack.motivator.notification
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class VoteReceiverTest {
+
+    @Test
+    fun from_upVote_returnsUp() {
+        assertEquals(VoteReceiver.VoteAction.Up(5L), VoteReceiver.VoteAction.from(5L, isUp = true))
+    }
+
+    @Test
+    fun from_downVote_returnsDown() {
+        assertEquals(VoteReceiver.VoteAction.Down(5L), VoteReceiver.VoteAction.from(5L, isUp = false))
+    }
+
+    @Test
+    fun from_invalidId_returnsIgnore() {
+        assertEquals(VoteReceiver.VoteAction.Ignore, VoteReceiver.VoteAction.from(0L, isUp = true))
+        assertEquals(VoteReceiver.VoteAction.Ignore, VoteReceiver.VoteAction.from(-1L, isUp = false))
+    }
+
+    @Test
+    fun requestCode_upAndDownDiffer_forSameMessage() {
+        assertNotEquals(
+            VoteReceiver.requestCode(7L, isUp = true),
+            VoteReceiver.requestCode(7L, isUp = false),
+        )
+    }
+
+    @Test
+    fun requestCode_differsAcrossMessages() {
+        assertNotEquals(
+            VoteReceiver.requestCode(7L, isUp = true),
+            VoteReceiver.requestCode(8L, isUp = true),
+        )
+    }
+}


### PR DESCRIPTION
@
## What & why

Reworks insult delivery on the watch to be **Google Play compliant**. The old path auto-launched a full-screen `InsultActivity` via `USE_FULL_SCREEN_INTENT`, which Play heavily restricts. This branch replaces that with a standard high-importance, votable notification:

- Insult is delivered as an `IMPORTANCE_HIGH` notification with 👎/👍 **action buttons**.
- Voting is handled by a new `VoteReceiver` (broadcast) → `MessageRepository.voteUp/voteDown`, then the notification is dismissed.
- `USE_FULL_SCREEN_INTENT` and the FSI activity flags are removed; Wear OS still surfaces the notification prominently on its own (system `DetailActivity2`) with **no** app-initiated full-screen launch.
- Each insult is tagged (`insult`) with `id = message.id` so it can no longer collide with the foreground-service notification id.
- Stats line ("N steps…") kept visible on the expanded notification via `BigTextStyle.setSummaryText`.
- `POST_NOTIFICATIONS` guard so a denied permission fails loudly in logs instead of silently dropping.

A debug-only `TestFireActivity` fires the real production delivery path for on-device testing:
`adb shell am start -n com.meatsack.motivator/.debug.TestFireActivity`

## On-device verification (physical Galaxy Watch, SM-L320, Wear OS)

| Check | Result |
|---|---|
| Notification posts with `insult` tag, off the FGS id | ✅ `0\|com.meatsack.motivator\|47\|insult\|…` |
| Insult text + stats line + 👎/👍 visible on expanded card | ✅ |
| 👎 action records a downvote + dismisses | ✅ DB `votesDown` 2 → 3, `InlineActionRunner` fired our PendingIntent |
| Prominent surfacing **without** a full-screen intent | ✅ system `DetailActivity2`, `fullScreenIntent=null`, no app-launched activity |

## Notes / follow-ups

- On Wear OS, tapping the notification opens the system detail view, not our `contentIntent` → `InsultActivity`. The content-intent is effectively dead weight on Wear; candidate for a later cleanup.
- The notification small icon is currently the generic `android.R.drawable.ic_dialog_alert` placeholder — worth replacing with a branded glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@