### PR TITLE
Watch→phone vote back-sync

### DIFF
--- a/docs/superpowers/plans/2026-06-22-vote-back-sync.md
+++ b/docs/superpowers/plans/2026-06-22-vote-back-sync.md
@@ -1,0 +1,534 @@
+# Watch→phone Vote Back-Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Flow watch vote counts back to the phone so the Library reflects them, via a new `/votes` Wear Data Layer channel that mirrors the existing phone→watch pipe in reverse.
+
+**Architecture:** After each vote on the watch, `WatchVoteSender` writes the watch's current vote counts (per message id, absolute) as a `/votes` DataItem; a new phone-side `PhoneVoteReceiver` (`WearableListenerService`) applies them with `MessageDao.setVotes`. The phone Library is already reactive (`getAllMessagesFlow()`), so it refreshes live. Everything is additive — each commit compiles and passes all module tests.
+
+**Tech Stack:** Kotlin, Wear Data Layer (`DataClient`/`WearableListenerService`/`DataMap`), Room (`MessageDao`), JUnit.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-vote-back-sync-design.md`
+
+**Branch:** `feature/vote-back-sync` (already created; spec already committed there).
+
+---
+
+## File Structure
+
+- `shared/.../sync/VoteSyncSerializer.kt` (new) — `VoteSnapshot` + pure `id|up|down` (de)serializer
+- `shared/.../sync/SyncChannel.kt` — add `PATH_VOTES` / `KEY_VOTE_DATA`
+- `shared/.../db/MessageDao.kt` — add `getVotedMessages()` + `setVotes(...)`
+- `wear/.../sync/WatchVoteSender.kt` (new) — read voted rows → write `/votes` DataItem
+- `wear/.../presentation/InsultActivity.kt` — fire `WatchVoteSender` after a vote
+- `mobile/.../sync/PhoneVoteReceiver.kt` (new) — apply `/votes` to the phone DB
+- `mobile/src/main/AndroidManifest.xml` — register `PhoneVoteReceiver`
+
+Build commands (Git Bash, Windows; `./gradlew` works):
+- `./gradlew :shared:testDebugUnitTest`
+- `./gradlew :shared:testDebugUnitTest :mobile:testDebugUnitTest :wear:testDebugUnitTest`
+- `./gradlew spotlessCheck` (auto-fix: `./gradlew spotlessApply && git add -u`)
+
+---
+
+### Task 1: `VoteSyncSerializer` (pure, TDD)
+
+The one genuinely new piece of logic: a symmetric `id|up|down` (de)serializer mirroring `MessageSerializer`, dropping malformed lines instead of throwing.
+
+**Files:**
+- Create: `shared/src/main/java/com/meatsack/shared/sync/VoteSyncSerializer.kt`
+- Test: `shared/src/test/java/com/meatsack/shared/sync/VoteSyncSerializerTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `shared/src/test/java/com/meatsack/shared/sync/VoteSyncSerializerTest.kt`:
+
+```kotlin
+package com.meatsack.shared.sync
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VoteSyncSerializerTest {
+
+    @Test fun roundTrip_preservesAllRows() {
+        val votes = listOf(
+            VoteSnapshot(42, 5, 2),
+            VoteSnapshot(7, 0, 1),
+            VoteSnapshot(100, 3, 0),
+        )
+        val serialized = VoteSyncSerializer.serialize(votes)
+        assertEquals(votes, VoteSyncSerializer.deserialize(serialized))
+    }
+
+    @Test fun deserialize_emptyString_returnsEmptyList() {
+        assertEquals(emptyList<VoteSnapshot>(), VoteSyncSerializer.deserialize(""))
+    }
+
+    @Test fun deserialize_dropsMalformedLines_keepsValid() {
+        // line 2 has too few fields; line 3 has a non-numeric id
+        val data = "42|5|2\nbroken|line\nabc|1|1\n7|0|3"
+        assertEquals(
+            listOf(VoteSnapshot(42, 5, 2), VoteSnapshot(7, 0, 3)),
+            VoteSyncSerializer.deserialize(data),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "com.meatsack.shared.sync.VoteSyncSerializerTest"`
+Expected: FAIL — unresolved reference `VoteSnapshot` / `VoteSyncSerializer`.
+
+- [ ] **Step 3: Implement**
+
+Create `shared/src/main/java/com/meatsack/shared/sync/VoteSyncSerializer.kt`:
+
+```kotlin
+package com.meatsack.shared.sync
+
+/** One message's vote counts, keyed by message id. */
+data class VoteSnapshot(val id: Long, val votesUp: Int, val votesDown: Int)
+
+/**
+ * Symmetric (de)serializer for the `/votes` Wear Data Layer channel (watch → phone).
+ * One snapshot per `\n`-separated line, 3 `|`-separated fields: id, votesUp, votesDown.
+ *
+ * Malformed lines are dropped (logged at WARN) rather than throwing, so a corrupt
+ * payload never takes down the receiver. Mirrors MessageSerializer.
+ */
+object VoteSyncSerializer {
+    private const val FIELD_COUNT = 3
+    private const val FIELD_SEPARATOR = "|"
+    private const val LINE_SEPARATOR = "\n"
+
+    fun serialize(votes: List<VoteSnapshot>): String =
+        votes.joinToString(LINE_SEPARATOR) { v ->
+            listOf(v.id, v.votesUp, v.votesDown).joinToString(FIELD_SEPARATOR)
+        }
+
+    fun deserialize(data: String): List<VoteSnapshot> {
+        if (data.isEmpty()) return emptyList()
+        return data.split(LINE_SEPARATOR).mapNotNull { parseLine(it) }
+    }
+
+    private fun parseLine(line: String): VoteSnapshot? {
+        val parts = line.split(FIELD_SEPARATOR)
+        if (parts.size != FIELD_COUNT) {
+            android.util.Log.w(
+                "VoteSyncSerializer",
+                "Dropped line with ${parts.size} fields (expected $FIELD_COUNT): ${line.take(80)}",
+            )
+            return null
+        }
+        return runCatching {
+            VoteSnapshot(
+                id = parts[0].toLong(),
+                votesUp = parts[1].toInt(),
+                votesDown = parts[2].toInt(),
+            )
+        }.onFailure { error ->
+            android.util.Log.w("VoteSyncSerializer", "Dropped malformed line: ${line.take(80)}", error)
+        }.getOrNull()
+    }
+}
+```
+
+(`android.util.Log.w` is safe in `:shared` JVM unit tests — the existing `MessageSerializerTest` exercises the same drop-malformed path, so the module is already configured for it.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "com.meatsack.shared.sync.VoteSyncSerializerTest"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Verify formatting & commit**
+
+Run: `./gradlew :shared:spotlessCheck` (fix with `./gradlew spotlessApply && git add -u` if needed).
+
+```bash
+git add shared/src/main/java/com/meatsack/shared/sync/VoteSyncSerializer.kt shared/src/test/java/com/meatsack/shared/sync/VoteSyncSerializerTest.kt
+git commit -m "feat(sync): add VoteSyncSerializer for the /votes channel"
+```
+
+---
+
+### Task 2: `/votes` channel constants + DAO vote methods
+
+Additive shared changes the sender and receiver will use. No unit test: `SyncChannel` is constants; the two DAO queries are Room SQL with no pre-commit harness in this project (DAO tests run under `:shared:connectedAndroidTest`, which needs an emulator) — they are exercised by the on-device smoke in Task 6.
+
+**Files:**
+- Modify: `shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt`
+- Modify: `shared/src/main/java/com/meatsack/shared/db/MessageDao.kt`
+
+- [ ] **Step 1: Add the channel constants**
+
+In `SyncChannel.kt`, add after `KEY_TIMESTAMP`:
+
+```kotlin
+    const val PATH_VOTES = "/votes"
+    const val KEY_VOTE_DATA = "vote_data"
+```
+
+- [ ] **Step 2: Add the DAO methods**
+
+In `MessageDao.kt`, add (e.g. after the existing `voteDown` query):
+
+```kotlin
+    @Query("SELECT * FROM messages WHERE votesUp > 0 OR votesDown > 0")
+    suspend fun getVotedMessages(): List<Message>
+
+    @Query("UPDATE messages SET votesUp = :votesUp, votesDown = :votesDown WHERE id = :messageId")
+    suspend fun setVotes(messageId: Long, votesUp: Int, votesDown: Int)
+```
+
+- [ ] **Step 3: Verify it compiles (Room KSP processes the new queries)**
+
+Run: `./gradlew :shared:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL (Room validates the new `@Query` SQL at compile time).
+
+- [ ] **Step 4: Verify formatting & commit**
+
+Run: `./gradlew :shared:spotlessCheck` (fix if needed).
+
+```bash
+git add shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt shared/src/main/java/com/meatsack/shared/db/MessageDao.kt
+git commit -m "feat(sync): add /votes channel constants + setVotes/getVotedMessages DAO"
+```
+
+---
+
+### Task 3: `WatchVoteSender` (watch side)
+
+Reads the watch's voted rows, serializes them, and writes the `/votes` DataItem. Mirrors `PhoneSyncSender` (sealed result + cancellation-safe catch). New file, not yet called — green on its own.
+
+**Files:**
+- Create: `wear/src/main/java/com/meatsack/motivator/sync/WatchVoteSender.kt`
+
+- [ ] **Step 1: Implement**
+
+Create `wear/src/main/java/com/meatsack/motivator/sync/WatchVoteSender.kt`:
+
+```kotlin
+package com.meatsack.motivator.sync
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import com.meatsack.shared.db.AppDatabase
+import com.meatsack.shared.sync.SyncChannel
+import com.meatsack.shared.sync.VoteSnapshot
+import com.meatsack.shared.sync.VoteSyncSerializer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Outcome of a vote back-sync. Mirrors PhoneSyncSender.SyncResult so callers can
+ * distinguish "nothing to send" from a real failure.
+ */
+sealed class VoteSyncResult {
+    data class Success(val count: Int) : VoteSyncResult()
+    data object NoVotes : VoteSyncResult()
+    data class Failed(val error: Throwable) : VoteSyncResult()
+}
+
+/**
+ * Pushes the watch's current vote counts to the phone over the /votes Data Layer
+ * channel. The reverse of PhoneSyncSender's forward (/messages) pipe. Absolute
+ * counts keyed by message id, with a timestamp so every vote propagates.
+ */
+class WatchVoteSender(private val context: Context) {
+
+    companion object {
+        private const val TAG = "WatchVoteSender"
+    }
+
+    suspend fun syncVotesToPhone(): VoteSyncResult {
+        val snapshots = AppDatabase.getDatabase(context).messageDao().getVotedMessages()
+            .map { VoteSnapshot(it.id, it.votesUp, it.votesDown) }
+
+        if (snapshots.isEmpty()) {
+            Log.d(TAG, "No votes to sync")
+            return VoteSyncResult.NoVotes
+        }
+
+        val request = PutDataMapRequest.create(SyncChannel.PATH_VOTES).apply {
+            dataMap.putString(SyncChannel.KEY_VOTE_DATA, VoteSyncSerializer.serialize(snapshots))
+            dataMap.putLong(SyncChannel.KEY_TIMESTAMP, System.currentTimeMillis())
+        }.asPutDataRequest().setUrgent()
+
+        return try {
+            Wearable.getDataClient(context).putDataItem(request).await()
+            Log.d(TAG, "Synced ${snapshots.size} vote rows to phone")
+            VoteSyncResult.Success(snapshots.size)
+        } catch (ce: CancellationException) {
+            // Don't absorb cancellation — propagating it keeps structured concurrency honest.
+            throw ce
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to sync votes", e)
+            VoteSyncResult.Failed(e)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :wear:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Verify formatting & commit**
+
+Run: `./gradlew :wear:spotlessCheck` (fix if needed).
+
+```bash
+git add wear/src/main/java/com/meatsack/motivator/sync/WatchVoteSender.kt
+git commit -m "feat(wear): add WatchVoteSender to push votes back to the phone"
+```
+
+---
+
+### Task 4: Fire the back-sync after each vote (`InsultActivity`)
+
+Wire `WatchVoteSender` into the existing `recordVote` so the snapshot is sent *after* the vote write commits (so `getVotedMessages` sees the new count). Framework/UI code — verified on-device, no unit test.
+
+**Files:**
+- Modify: `wear/src/main/java/com/meatsack/motivator/presentation/InsultActivity.kt`
+
+- [ ] **Step 1: Add the import**
+
+In `InsultActivity.kt`, add to the imports:
+
+```kotlin
+import com.meatsack.motivator.sync.WatchVoteSender
+```
+
+- [ ] **Step 2: Construct the sender in `onCreate`**
+
+After the existing `val repo = MessageRepository(db.messageDao())` line, add:
+
+```kotlin
+        val voteSender = WatchVoteSender(applicationContext)
+```
+
+- [ ] **Step 3: Pass the sender through the vote callbacks**
+
+Change the two `recordVote(...)` calls inside `setContent` to pass `voteSender`:
+
+```kotlin
+                onThumbsUp = {
+                    recordVote(appScope, voteSender, messageId) { repo.voteUp(it) }
+                    finish()
+                },
+                onThumbsDown = {
+                    recordVote(appScope, voteSender, messageId) { repo.voteDown(it) }
+                    finish()
+                },
+```
+
+- [ ] **Step 4: Trigger the sync after the write in `recordVote`**
+
+Replace the existing `recordVote` function with the version that takes the sender and pushes after the write succeeds:
+
+```kotlin
+    private inline fun recordVote(
+        scope: kotlinx.coroutines.CoroutineScope,
+        voteSender: WatchVoteSender,
+        messageId: Long,
+        crossinline write: suspend (Long) -> Unit,
+    ) {
+        if (messageId <= 0L) return
+        scope.launch {
+            try {
+                write(messageId)
+                // Best-effort back-sync; the vote is already persisted locally and the
+                // next vote re-sends the full snapshot, so a failure here is non-fatal.
+                voteSender.syncVotesToPhone()
+            } catch (t: Throwable) {
+                Log.e("InsultActivity", "Vote write failed for id=$messageId", t)
+            }
+        }
+    }
+```
+
+- [ ] **Step 5: Verify it compiles & formatting**
+
+Run: `./gradlew :wear:compileDebugKotlin && ./gradlew :wear:spotlessCheck`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wear/src/main/java/com/meatsack/motivator/presentation/InsultActivity.kt
+git commit -m "feat(wear): push votes to phone after each vote in InsultActivity"
+```
+
+---
+
+### Task 5: `PhoneVoteReceiver` + manifest registration (phone side)
+
+A new `WearableListenerService` (the phone's first) that applies `/votes` to the phone DB via `setVotes`. Mirrors `WatchSyncReceiver` in reverse. Framework code — verified on-device.
+
+**Files:**
+- Create: `mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneVoteReceiver.kt`
+- Modify: `mobile/src/main/AndroidManifest.xml`
+
+- [ ] **Step 1: Implement the receiver**
+
+Create `mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneVoteReceiver.kt`:
+
+```kotlin
+package com.meatsack.motivator.mobile.sync
+
+import android.util.Log
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.WearableListenerService
+import com.meatsack.motivator.mobile.MeatsackMobileApp
+import com.meatsack.shared.db.AppDatabase
+import com.meatsack.shared.sync.SyncChannel
+import com.meatsack.shared.sync.VoteSyncSerializer
+import kotlinx.coroutines.launch
+
+/**
+ * Applies vote counts pushed from the watch over the /votes channel to the phone
+ * Room DB (absolute set, keyed by message id). The reverse of WatchSyncReceiver,
+ * which receives the forward (/messages) pipe.
+ */
+class PhoneVoteReceiver : WearableListenerService() {
+
+    companion object {
+        private const val TAG = "PhoneVoteReceiver"
+
+        // Bound the blast radius of a malformed/hostile payload (matches WatchSyncReceiver).
+        private const val MAX_INCOMING_VOTES = 500
+    }
+
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        dataEvents.forEach { event ->
+            val path = event.dataItem.uri.path
+            if (path != SyncChannel.PATH_VOTES) return@forEach
+            val sourceNode = event.dataItem.uri.host
+            val dataMap = DataMapItem.fromDataItem(event.dataItem).dataMap
+            val serialized = dataMap.getString(SyncChannel.KEY_VOTE_DATA)
+            if (serialized == null) {
+                Log.w(
+                    TAG,
+                    "Missing ${SyncChannel.KEY_VOTE_DATA} in ${SyncChannel.PATH_VOTES} from node=$sourceNode",
+                )
+                return@forEach
+            }
+
+            val votes = VoteSyncSerializer.deserialize(serialized)
+            if (votes.isEmpty()) {
+                Log.w(TAG, "Empty or fully-malformed vote payload from node=$sourceNode")
+                return@forEach
+            }
+            if (votes.size > MAX_INCOMING_VOTES) {
+                Log.w(TAG, "Dropping oversized vote sync from node=$sourceNode size=${votes.size}")
+                return@forEach
+            }
+
+            val scope = (applicationContext as MeatsackMobileApp).applicationScope
+            scope.launch {
+                try {
+                    val dao = AppDatabase.getDatabase(applicationContext).messageDao()
+                    votes.forEach { dao.setVotes(it.id, it.votesUp, it.votesDown) }
+                    Log.d(TAG, "Applied ${votes.size} vote rows from node=$sourceNode")
+                } catch (t: Throwable) {
+                    Log.e(TAG, "Failed to apply ${votes.size} vote rows from $sourceNode", t)
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register the service in the manifest**
+
+In `mobile/src/main/AndroidManifest.xml`, inside `<application>` and after the `<activity>` block (before `</application>`), add:
+
+```xml
+        <service
+            android:name=".sync.PhoneVoteReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+                <data
+                    android:scheme="wear"
+                    android:host="*"
+                    android:pathPrefix="/votes" />
+            </intent-filter>
+        </service>
+```
+
+- [ ] **Step 3: Verify it compiles & formatting**
+
+Run: `./gradlew :mobile:compileDebugKotlin && ./gradlew :mobile:spotlessCheck`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneVoteReceiver.kt mobile/src/main/AndroidManifest.xml
+git commit -m "feat(mobile): receive /votes and apply watch votes to the phone DB"
+```
+
+---
+
+### Task 6: Full build + on-device verification + PR
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full build + all tests**
+
+Run: `./gradlew build`
+Expected: BUILD SUCCESSFUL (all modules compile, lint clean, all unit tests incl. `VoteSyncSerializerTest` pass).
+
+- [ ] **Step 2: Install on the paired emulators**
+
+```bash
+./gradlew :mobile:assembleDebug :wear:assembleDebug
+adb -s <phone-id> install -r mobile/build/outputs/apk/debug/mobile-debug.apk
+adb -s <watch-id> install -r wear/build/outputs/apk/debug/wear-debug.apk
+adb -s <watch-id> shell pm grant com.meatsack.motivator android.permission.POST_NOTIFICATIONS
+```
+
+- [ ] **Step 3: Fire an insult on the watch and vote**
+
+Trigger the full-screen insult (e.g. via the debug `TestFireActivity` if present, or by letting an insult fire), then tap 👍. Watch the sender log:
+
+```bash
+adb -s <watch-id> logcat -d -s WatchVoteSender | tail -3
+```
+
+Expected: `Synced N vote rows to phone`.
+
+- [ ] **Step 4: Confirm the phone applied the vote**
+
+```bash
+adb -s <phone-id> logcat -d -s PhoneVoteReceiver | tail -3
+```
+
+Expected: `Applied N vote rows from node=...`. Then open the phone app's **Library** tab and confirm the voted message's `👍/👎` count reflects the watch vote (the list is reactive, so it updates without reopening).
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+git push -u origin feature/vote-back-sync
+gh pr create --fill --base main
+```
+
+Then review with `pr-review-toolkit:review-pr` before merging (per project workflow).
+
+---
+
+## Notes for the implementer
+
+- **Entirely additive:** no existing field/method is removed or changed in a breaking way, so every task commits green under the pre-commit hook (which builds + unit-tests all three modules).
+- **id-match invariant:** back-sync keys on message `id`, valid only because every message is born on the phone (identical seed order → matching ids; AI/custom created on phone then synced down). Do not add watch-local message creation.
+- **Absolute counts, not deltas:** `setVotes` overwrites with the watch's current counts — idempotent under Data Layer redelivery. A delta scheme would double-count.
+- **Eventual consistency:** the manual "Sync to Watch" (`/messages`) still carries the phone's vote counts; back-sync keeps them current. The sub-second vote-then-sync race self-heals on the next vote. (Accepted per spec.)
+- **Trigger scope:** only `InsultActivity` votes fire the back-sync. The orphaned `VoteReceiver` (dead notification-action handler) is intentionally not wired.
+- **Do not commit to `main`** — work stays on `feature/vote-back-sync`; PR into `main`.

--- a/docs/superpowers/specs/2026-06-22-vote-back-sync-design.md
+++ b/docs/superpowers/specs/2026-06-22-vote-back-sync-design.md
@@ -1,0 +1,118 @@
+# Watch→phone vote back-sync
+
+**Date:** 2026-06-22
+**Branch:** `feature/vote-back-sync`
+**Status:** Designed — approved, proceeding to plan
+
+## Problem
+
+Votes are recorded only on the watch (`InsultActivity` 👍/👎 → `MessageRepository.voteUp/voteDown`
+→ `MessageDao` increment). The phone `LibraryScreen` already *displays* `👍 votesUp 👎 votesDown`
+and reads via the reactive `getAllMessagesFlow()`, but nothing watch-originated ever reaches the
+phone: the Wear Data Layer sync is one-way (phone→watch, `/messages`), and there is no phone-side
+`WearableListenerService`. So watch votes never show up in the phone Library.
+
+## Goal
+
+Flow vote counts from the watch back to the phone so the Library reflects them, by adding a new
+`/votes` Data Layer channel that mirrors the existing forward pipe in reverse.
+
+## Final design
+
+### Architecture — reverse of the existing forward sync
+
+- **Watch side (sender):** after a vote, push the watch's current vote counts as a `/votes` DataItem.
+- **Phone side (receiver):** a new `WearableListenerService` applies those counts to the phone DB.
+- **Phone Library:** unchanged — `getAllMessagesFlow()` is reactive, so it refreshes live once the
+  phone DB updates.
+
+### The id-match invariant (load-bearing)
+
+Back-sync keys on the message `id`. This is safe only because **every message is born on the phone**:
+both DBs seed from the identical `SeedData` list in the same order (so Room auto-generated ids match,
+1..N), and AI/custom messages are created on the phone and synced down with explicit ids. The watch
+never mints an id independently. Therefore "watch says message 42 now has 5 upvotes" maps correctly to
+phone row 42. If the watch ever creates messages locally, this scheme breaks — keep id minting
+phone-only.
+
+### Absolute counts, not deltas
+
+The watch sends its **current** `votesUp`/`votesDown`; the phone **sets** them (absolute `UPDATE`).
+Idempotent under Data Layer redelivery (re-applying the same snapshot is a no-op), whereas a delta
+scheme would double-count on duplicate delivery. `KEY_TIMESTAMP` is included so a vote that returns to
+a previously-sent snapshot (e.g. up then down) still produces distinct content and fires
+`onDataChanged` (same rationale as `/messages`; deliberately unlike `/settings`, which omits the
+timestamp).
+
+### Trigger
+
+Automatic, fire-and-forget, **after each vote** on the watch (in `InsultActivity.recordVote`, on the
+app scope so it outlives the activity). Votes appear in the phone Library within ~1s. The orphaned
+`VoteReceiver` (notification-action handler, currently dead code) is *not* wired — noted for if it is
+ever revived.
+
+### Conflict handling — eventual consistency
+
+Votes originate only on the watch (the vote authority); the phone is a mirror. The existing manual
+"Sync to Watch" (`/messages`) carries the phone's vote counts and `insertAll(REPLACE)`s them on the
+watch — back-sync keeps the phone's counts current, so the forward sync then carries accurate values.
+The only anomaly is voting on the watch and tapping "Sync to Watch" in the sub-second before back-sync
+lands; it self-heals on the next vote. Accepted; not worth merging-on-REPLACE complexity for v1.
+
+## Components
+
+| Module | File | Change |
+| --- | --- | --- |
+| shared | `sync/SyncChannel.kt` | Add `PATH_VOTES = "/votes"`, `KEY_VOTE_DATA = "vote_data"` |
+| shared | `sync/VoteSyncSerializer.kt` (new) | `VoteSnapshot(id, votesUp, votesDown)` + `serialize`/`deserialize` (`id\|up\|down` per line, drops malformed lines) — pure, unit-tested |
+| shared | `db/MessageDao.kt` | Add `getVotedMessages()` (`WHERE votesUp > 0 OR votesDown > 0`) and `setVotes(messageId, votesUp, votesDown)` (absolute `UPDATE`) |
+| wear | `sync/WatchVoteSender.kt` (new) | Read voted messages → `VoteSnapshot` → serialize → write `/votes` DataItem (`setUrgent`, timestamp). Mirrors `PhoneSyncSender` (sealed result + cancellation-safe catch) |
+| wear | `presentation/InsultActivity.kt` | After the existing `repo.voteUp/voteDown` in `recordVote`, fire `WatchVoteSender` on the app scope |
+| mobile | `sync/PhoneVoteReceiver.kt` (new) | `WearableListenerService`; on `/votes`, deserialize and `dao.setVotes(...)` per id on `MeatsackMobileApp.applicationScope`; size-bounded. Mirrors `WatchSyncReceiver` |
+| mobile | `AndroidManifest.xml` | Register `PhoneVoteReceiver` as `<service android:exported="true">` with a `DATA_CHANGED` intent-filter on `/votes` (the phone's first service) |
+
+### Serialization format (`/votes`)
+
+One vote per line, three `|`-delimited fields, `\n`-separated:
+
+```
+<id:Long>|<votesUp:Int>|<votesDown:Int>
+```
+
+Example: `42|5|2\n7|0|1`. Malformed lines are dropped with a warning (mirrors `MessageSerializer`).
+Only messages with `votesUp > 0 || votesDown > 0` are sent (leaner; unvoted rows already read 0/0 on
+the phone).
+
+## Data flow
+
+1. User taps 👍/👎 in `InsultActivity` on the watch → `MessageRepository.voteUp/voteDown` (DAO increment).
+2. `recordVote` then calls `WatchVoteSender.syncVotesToPhone()` on the app scope → writes `/votes` DataItem.
+3. Phone `PhoneVoteReceiver.onDataChanged` filters `/votes`, deserializes, applies `dao.setVotes(id, up, down)` per row.
+4. Phone `LibraryViewModel` (`getAllMessagesFlow()`) emits the updated list → `LibraryScreen` shows new counts.
+
+## Error handling
+
+- `WatchVoteSender`: try/catch around the `putDataItem().await()`, rethrow `CancellationException`,
+  log+swallow others, return a sealed result (mirrors `PhoneSyncSender.SyncResult`). A failed back-sync
+  is non-fatal — the vote is already recorded locally and the next vote re-sends the full snapshot.
+- `PhoneVoteReceiver`: null/empty/oversized payloads logged and skipped (mirror `WatchSyncReceiver`'s
+  `MAX_INCOMING_MESSAGES` guard); per-row apply wrapped so one bad row doesn't abort the batch.
+
+## Testing
+
+- **`VoteSyncSerializer`** unit tests: round-trip (multiple rows incl. zero values), malformed-line
+  tolerance, empty input → empty list.
+- **`MessageDao.setVotes`/`getVotedMessages`**: Room queries — extend the existing
+  `shared:connectedAndroidTest` (emulator) if practical; otherwise verified on-device.
+- **`WatchVoteSender`/`PhoneVoteReceiver`**: framework-bound (DataClient / WearableListenerService),
+  no unit harness in this project — verified on the paired emulators, like the existing forward
+  sender/receiver.
+- **Manual (emulator):** vote on the watch → phone `PhoneVoteReceiver` logs the applied snapshot → phone
+  Library count updates live.
+
+## Out of scope / notes
+
+- The orphaned `VoteReceiver` is not wired into back-sync (dead code; revive-and-wire later if needed).
+- No phone-side UI change — the Library already renders the counts.
+- `votesDown >= 3` deactivation logic is unchanged; back-sync simply reflects the counts so the phone
+  shows the same picture the watch uses for eligibility.

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -23,6 +23,18 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:name=".sync.PhoneVoteReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+                <data
+                    android:scheme="wear"
+                    android:host="*"
+                    android:pathPrefix="/votes" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneVoteReceiver.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneVoteReceiver.kt
@@ -1,0 +1,64 @@
+package com.meatsack.motivator.mobile.sync
+
+import android.util.Log
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.WearableListenerService
+import com.meatsack.motivator.mobile.MeatsackMobileApp
+import com.meatsack.shared.db.AppDatabase
+import com.meatsack.shared.sync.SyncChannel
+import com.meatsack.shared.sync.VoteSyncSerializer
+import kotlinx.coroutines.launch
+
+/**
+ * Applies vote counts pushed from the watch over the /votes channel to the phone
+ * Room DB (absolute set, keyed by message id). The reverse of WatchSyncReceiver,
+ * which receives the forward (/messages) pipe.
+ */
+class PhoneVoteReceiver : WearableListenerService() {
+
+    companion object {
+        private const val TAG = "PhoneVoteReceiver"
+
+        // Bound the blast radius of a malformed/hostile payload (matches WatchSyncReceiver).
+        private const val MAX_INCOMING_VOTES = 500
+    }
+
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        dataEvents.forEach { event ->
+            val path = event.dataItem.uri.path
+            if (path != SyncChannel.PATH_VOTES) return@forEach
+            val sourceNode = event.dataItem.uri.host
+            val dataMap = DataMapItem.fromDataItem(event.dataItem).dataMap
+            val serialized = dataMap.getString(SyncChannel.KEY_VOTE_DATA)
+            if (serialized == null) {
+                Log.w(
+                    TAG,
+                    "Missing ${SyncChannel.KEY_VOTE_DATA} in ${SyncChannel.PATH_VOTES} from node=$sourceNode",
+                )
+                return@forEach
+            }
+
+            val votes = VoteSyncSerializer.deserialize(serialized)
+            if (votes.isEmpty()) {
+                Log.w(TAG, "Empty or fully-malformed vote payload from node=$sourceNode")
+                return@forEach
+            }
+            if (votes.size > MAX_INCOMING_VOTES) {
+                Log.w(TAG, "Dropping oversized vote sync from node=$sourceNode size=${votes.size}")
+                return@forEach
+            }
+
+            val scope = (applicationContext as MeatsackMobileApp).applicationScope
+            scope.launch {
+                try {
+                    val dao = AppDatabase.getDatabase(applicationContext).messageDao()
+                    votes.forEach { dao.setVotes(it.id, it.votesUp, it.votesDown) }
+                    Log.d(TAG, "Applied ${votes.size} vote rows from node=$sourceNode")
+                } catch (t: Throwable) {
+                    Log.e(TAG, "Failed to apply ${votes.size} vote rows from $sourceNode", t)
+                }
+            }
+        }
+    }
+}

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneVoteReceiver.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneVoteReceiver.kt
@@ -19,9 +19,6 @@ class PhoneVoteReceiver : WearableListenerService() {
 
     companion object {
         private const val TAG = "PhoneVoteReceiver"
-
-        // Bound the blast radius of a malformed/hostile payload (matches WatchSyncReceiver).
-        private const val MAX_INCOMING_VOTES = 500
     }
 
     override fun onDataChanged(dataEvents: DataEventBuffer) {
@@ -44,7 +41,7 @@ class PhoneVoteReceiver : WearableListenerService() {
                 Log.w(TAG, "Empty or fully-malformed vote payload from node=$sourceNode")
                 return@forEach
             }
-            if (votes.size > MAX_INCOMING_VOTES) {
+            if (votes.size > SyncChannel.MAX_VOTE_ROWS) {
                 Log.w(TAG, "Dropping oversized vote sync from node=$sourceNode size=${votes.size}")
                 return@forEach
             }

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneVoteReceiver.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneVoteReceiver.kt
@@ -8,6 +8,7 @@ import com.meatsack.motivator.mobile.MeatsackMobileApp
 import com.meatsack.shared.db.AppDatabase
 import com.meatsack.shared.sync.SyncChannel
 import com.meatsack.shared.sync.VoteSyncSerializer
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 /**
@@ -48,13 +49,20 @@ class PhoneVoteReceiver : WearableListenerService() {
 
             val scope = (applicationContext as MeatsackMobileApp).applicationScope
             scope.launch {
-                try {
-                    val dao = AppDatabase.getDatabase(applicationContext).messageDao()
-                    votes.forEach { dao.setVotes(it.id, it.votesUp, it.votesDown) }
-                    Log.d(TAG, "Applied ${votes.size} vote rows from node=$sourceNode")
-                } catch (t: Throwable) {
-                    Log.e(TAG, "Failed to apply ${votes.size} vote rows from $sourceNode", t)
+                val dao = AppDatabase.getDatabase(applicationContext).messageDao()
+                // Per-row boundary so one bad row doesn't abort the rest of the batch.
+                var applied = 0
+                votes.forEach { vote ->
+                    try {
+                        dao.setVotes(vote.id, vote.votesUp, vote.votesDown)
+                        applied++
+                    } catch (ce: CancellationException) {
+                        throw ce
+                    } catch (t: Throwable) {
+                        Log.e(TAG, "Failed to apply vote row id=${vote.id} from node=$sourceNode", t)
+                    }
                 }
+                Log.d(TAG, "Applied $applied/${votes.size} vote rows from node=$sourceNode")
             }
         }
     }

--- a/shared/src/androidTest/java/com/meatsack/shared/db/MessageDaoTest.kt
+++ b/shared/src/androidTest/java/com/meatsack/shared/db/MessageDaoTest.kt
@@ -116,4 +116,32 @@ class MessageDaoTest {
         val updated = dao.getAllMessages().first()
         assertEquals(2, updated.votesUp)
     }
+
+    @Test
+    fun getVotedMessagesReturnsOnlyVoted() = runBlocking {
+        dao.insertAll(
+            listOf(
+                testMessage("unvoted"),
+                testMessage("upvoted"),
+                testMessage("downvoted"),
+            ),
+        )
+        val all = dao.getAllMessages()
+        dao.voteUp(all.first { it.text == "upvoted" }.id)
+        dao.voteDown(all.first { it.text == "downvoted" }.id)
+        val voted = dao.getVotedMessages()
+        assertEquals(setOf("upvoted", "downvoted"), voted.map { it.text }.toSet())
+    }
+
+    @Test
+    fun setVotesOverwritesAbsolutely() = runBlocking {
+        dao.insertAll(listOf(testMessage("msg")))
+        val msg = dao.getAllMessages().first()
+        dao.voteUp(msg.id)
+        dao.voteUp(msg.id) // votesUp now 2
+        dao.setVotes(msg.id, votesUp = 5, votesDown = 1) // absolute overwrite, not increment
+        val updated = dao.getAllMessages().first()
+        assertEquals(5, updated.votesUp)
+        assertEquals(1, updated.votesDown)
+    }
 }

--- a/shared/src/main/java/com/meatsack/shared/db/MessageDao.kt
+++ b/shared/src/main/java/com/meatsack/shared/db/MessageDao.kt
@@ -39,6 +39,12 @@ interface MessageDao {
     @Query("UPDATE messages SET votesDown = votesDown + 1 WHERE id = :messageId")
     suspend fun voteDown(messageId: Long)
 
+    @Query("SELECT * FROM messages WHERE votesUp > 0 OR votesDown > 0")
+    suspend fun getVotedMessages(): List<Message>
+
+    @Query("UPDATE messages SET votesUp = :votesUp, votesDown = :votesDown WHERE id = :messageId")
+    suspend fun setVotes(messageId: Long, votesUp: Int, votesDown: Int)
+
     @Query("UPDATE messages SET lastShownTimestamp = :timestamp WHERE id = :messageId")
     suspend fun markShown(messageId: Long, timestamp: Long)
 

--- a/shared/src/main/java/com/meatsack/shared/db/MessageDao.kt
+++ b/shared/src/main/java/com/meatsack/shared/db/MessageDao.kt
@@ -42,6 +42,8 @@ interface MessageDao {
     @Query("SELECT * FROM messages WHERE votesUp > 0 OR votesDown > 0")
     suspend fun getVotedMessages(): List<Message>
 
+    // Absolute set (back-sync applies the watch's authoritative counts),
+    // unlike voteUp/voteDown which increment.
     @Query("UPDATE messages SET votesUp = :votesUp, votesDown = :votesDown WHERE id = :messageId")
     suspend fun setVotes(messageId: Long, votesUp: Int, votesDown: Int)
 

--- a/shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt
@@ -9,4 +9,6 @@ object SyncChannel {
     const val PATH_MESSAGES = "/messages"
     const val KEY_MESSAGE_DATA = "message_data"
     const val KEY_TIMESTAMP = "timestamp"
+    const val PATH_VOTES = "/votes"
+    const val KEY_VOTE_DATA = "vote_data"
 }

--- a/shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt
@@ -11,4 +11,12 @@ object SyncChannel {
     const val KEY_TIMESTAMP = "timestamp"
     const val PATH_VOTES = "/votes"
     const val KEY_VOTE_DATA = "vote_data"
+
+    /**
+     * Max vote rows in one /votes payload. The watch caps its send to this so the
+     * phone never has to reject a legitimate back-sync; well under the ~100 KB
+     * DataItem limit (2000 rows x ~13 chars) and far above any realistic voted-
+     * message count.
+     */
+    const val MAX_VOTE_ROWS = 2000
 }

--- a/shared/src/main/java/com/meatsack/shared/sync/VoteSyncSerializer.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/VoteSyncSerializer.kt
@@ -1,0 +1,47 @@
+package com.meatsack.shared.sync
+
+/** One message's vote counts, keyed by message id. */
+data class VoteSnapshot(val id: Long, val votesUp: Int, val votesDown: Int)
+
+/**
+ * Symmetric (de)serializer for the `/votes` Wear Data Layer channel (watch → phone).
+ * One snapshot per `\n`-separated line, 3 `|`-separated fields: id, votesUp, votesDown.
+ *
+ * Malformed lines are dropped (logged at WARN) rather than throwing, so a corrupt
+ * payload never takes down the receiver. Mirrors MessageSerializer.
+ */
+object VoteSyncSerializer {
+    private const val FIELD_COUNT = 3
+    private const val FIELD_SEPARATOR = "|"
+    private const val LINE_SEPARATOR = "\n"
+
+    fun serialize(votes: List<VoteSnapshot>): String =
+        votes.joinToString(LINE_SEPARATOR) { v ->
+            listOf(v.id, v.votesUp, v.votesDown).joinToString(FIELD_SEPARATOR)
+        }
+
+    fun deserialize(data: String): List<VoteSnapshot> {
+        if (data.isEmpty()) return emptyList()
+        return data.split(LINE_SEPARATOR).mapNotNull { parseLine(it) }
+    }
+
+    private fun parseLine(line: String): VoteSnapshot? {
+        val parts = line.split(FIELD_SEPARATOR)
+        if (parts.size != FIELD_COUNT) {
+            android.util.Log.w(
+                "VoteSyncSerializer",
+                "Dropped line with ${parts.size} fields (expected $FIELD_COUNT): ${line.take(80)}",
+            )
+            return null
+        }
+        return runCatching {
+            VoteSnapshot(
+                id = parts[0].toLong(),
+                votesUp = parts[1].toInt(),
+                votesDown = parts[2].toInt(),
+            )
+        }.onFailure { error ->
+            android.util.Log.w("VoteSyncSerializer", "Dropped malformed line: ${line.take(80)}", error)
+        }.getOrNull()
+    }
+}

--- a/shared/src/test/java/com/meatsack/shared/sync/VoteSyncSerializerTest.kt
+++ b/shared/src/test/java/com/meatsack/shared/sync/VoteSyncSerializerTest.kt
@@ -1,0 +1,30 @@
+package com.meatsack.shared.sync
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VoteSyncSerializerTest {
+
+    @Test fun roundTrip_preservesAllRows() {
+        val votes = listOf(
+            VoteSnapshot(42, 5, 2),
+            VoteSnapshot(7, 0, 1),
+            VoteSnapshot(100, 3, 0),
+        )
+        val serialized = VoteSyncSerializer.serialize(votes)
+        assertEquals(votes, VoteSyncSerializer.deserialize(serialized))
+    }
+
+    @Test fun deserialize_emptyString_returnsEmptyList() {
+        assertEquals(emptyList<VoteSnapshot>(), VoteSyncSerializer.deserialize(""))
+    }
+
+    @Test fun deserialize_dropsMalformedLines_keepsValid() {
+        // line 2 has too few fields; line 3 has a non-numeric id
+        val data = "42|5|2\nbroken|line\nabc|1|1\n7|0|3"
+        assertEquals(
+            listOf(VoteSnapshot(42, 5, 2), VoteSnapshot(7, 0, 3)),
+            VoteSyncSerializer.deserialize(data),
+        )
+    }
+}

--- a/shared/src/test/java/com/meatsack/shared/sync/VoteSyncSerializerTest.kt
+++ b/shared/src/test/java/com/meatsack/shared/sync/VoteSyncSerializerTest.kt
@@ -1,6 +1,7 @@
 package com.meatsack.shared.sync
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VoteSyncSerializerTest {
@@ -17,6 +18,24 @@ class VoteSyncSerializerTest {
 
     @Test fun deserialize_emptyString_returnsEmptyList() {
         assertEquals(emptyList<VoteSnapshot>(), VoteSyncSerializer.deserialize(""))
+    }
+
+    @Test fun serialize_emptyList_returnsEmptyString() {
+        assertEquals("", VoteSyncSerializer.serialize(emptyList()))
+    }
+
+    @Test fun roundTrip_emptyList() {
+        val empty = emptyList<VoteSnapshot>()
+        assertEquals(empty, VoteSyncSerializer.deserialize(VoteSyncSerializer.serialize(empty)))
+    }
+
+    @Test fun roundTrip_maxVoteRows_allPreservedAndUnderDataItemLimit() {
+        val votes = (1..SyncChannel.MAX_VOTE_ROWS).map { VoteSnapshot(it.toLong(), it % 7, it % 3) }
+        val serialized = VoteSyncSerializer.serialize(votes)
+        assertEquals(votes, VoteSyncSerializer.deserialize(serialized))
+        // Backs the sizing claim in SyncChannel.MAX_VOTE_ROWS's doc: a full payload
+        // stays well under the ~100 KB Data Layer DataItem limit.
+        assertTrue("payload was ${serialized.length} chars", serialized.length < 100_000)
     }
 
     @Test fun deserialize_dropsMalformedLines_keepsValid() {

--- a/shared/src/test/java/com/meatsack/shared/sync/VoteSyncSerializerTest.kt
+++ b/shared/src/test/java/com/meatsack/shared/sync/VoteSyncSerializerTest.kt
@@ -20,7 +20,8 @@ class VoteSyncSerializerTest {
     }
 
     @Test fun deserialize_dropsMalformedLines_keepsValid() {
-        // line 2 has too few fields; line 3 has a non-numeric id
+        // line 2: too few fields (dropped on the field-count guard);
+        // line 3: 3 fields but a non-numeric id (dropped on parse failure)
         val data = "42|5|2\nbroken|line\nabc|1|1\n7|0|3"
         assertEquals(
             listOf(VoteSnapshot(42, 5, 2), VoteSnapshot(7, 0, 3)),

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.play.services.wearable)
+    implementation(libs.kotlinx.coroutines.play.services)
     implementation(libs.androidx.health.services.client)
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.guava)

--- a/wear/src/main/java/com/meatsack/motivator/presentation/InsultActivity.kt
+++ b/wear/src/main/java/com/meatsack/motivator/presentation/InsultActivity.kt
@@ -7,8 +7,10 @@ import androidx.activity.compose.setContent
 import com.meatsack.motivator.MeatsackWearApp
 import com.meatsack.motivator.messages.MessageRepository
 import com.meatsack.motivator.notification.InsultNotificationService
+import com.meatsack.motivator.sync.VoteSyncResult
 import com.meatsack.motivator.sync.WatchVoteSender
 import com.meatsack.shared.db.AppDatabase
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 class InsultActivity : ComponentActivity() {
@@ -49,13 +51,22 @@ class InsultActivity : ComponentActivity() {
     ) {
         if (messageId <= 0L) return
         scope.launch {
+            // The local write is authoritative (the watch is the vote authority), so a
+            // failure here is real data loss — keep it on its own failure boundary.
             try {
                 write(messageId)
-                // Best-effort back-sync; the vote is already persisted locally and the
-                // next vote re-sends the full snapshot, so a failure here is non-fatal.
-                voteSender.syncVotesToPhone()
+            } catch (ce: CancellationException) {
+                throw ce
             } catch (t: Throwable) {
-                Log.e("InsultActivity", "Vote write failed for id=$messageId", t)
+                Log.e("InsultActivity", "Local vote write failed for id=$messageId", t)
+                return@launch
+            }
+            // Best-effort back-sync: the vote is already persisted locally and the next
+            // vote re-sends the full snapshot, so a failure here self-heals.
+            when (val result = voteSender.syncVotesToPhone()) {
+                is VoteSyncResult.Failed ->
+                    Log.w("InsultActivity", "Vote back-sync failed for id=$messageId; retries on next vote", result.error)
+                else -> Unit
             }
         }
     }

--- a/wear/src/main/java/com/meatsack/motivator/presentation/InsultActivity.kt
+++ b/wear/src/main/java/com/meatsack/motivator/presentation/InsultActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.setContent
 import com.meatsack.motivator.MeatsackWearApp
 import com.meatsack.motivator.messages.MessageRepository
 import com.meatsack.motivator.notification.InsultNotificationService
+import com.meatsack.motivator.sync.WatchVoteSender
 import com.meatsack.shared.db.AppDatabase
 import kotlinx.coroutines.launch
 
@@ -22,17 +23,18 @@ class InsultActivity : ComponentActivity() {
         val appScope = (application as MeatsackWearApp).applicationScope
         val db = AppDatabase.getDatabase(applicationContext)
         val repo = MessageRepository(db.messageDao())
+        val voteSender = WatchVoteSender(applicationContext)
 
         setContent {
             InsultScreen(
                 insultText = messageText,
                 statsText = statsText,
                 onThumbsUp = {
-                    recordVote(appScope, messageId) { repo.voteUp(it) }
+                    recordVote(appScope, voteSender, messageId) { repo.voteUp(it) }
                     finish()
                 },
                 onThumbsDown = {
-                    recordVote(appScope, messageId) { repo.voteDown(it) }
+                    recordVote(appScope, voteSender, messageId) { repo.voteDown(it) }
                     finish()
                 },
             )
@@ -41,6 +43,7 @@ class InsultActivity : ComponentActivity() {
 
     private inline fun recordVote(
         scope: kotlinx.coroutines.CoroutineScope,
+        voteSender: WatchVoteSender,
         messageId: Long,
         crossinline write: suspend (Long) -> Unit,
     ) {
@@ -48,6 +51,9 @@ class InsultActivity : ComponentActivity() {
         scope.launch {
             try {
                 write(messageId)
+                // Best-effort back-sync; the vote is already persisted locally and the
+                // next vote re-sends the full snapshot, so a failure here is non-fatal.
+                voteSender.syncVotesToPhone()
             } catch (t: Throwable) {
                 Log.e("InsultActivity", "Vote write failed for id=$messageId", t)
             }

--- a/wear/src/main/java/com/meatsack/motivator/sync/WatchVoteSender.kt
+++ b/wear/src/main/java/com/meatsack/motivator/sync/WatchVoteSender.kt
@@ -34,6 +34,7 @@ class WatchVoteSender(private val context: Context) {
 
     suspend fun syncVotesToPhone(): VoteSyncResult {
         val snapshots = AppDatabase.getDatabase(context).messageDao().getVotedMessages()
+            .take(SyncChannel.MAX_VOTE_ROWS)
             .map { VoteSnapshot(it.id, it.votesUp, it.votesDown) }
 
         if (snapshots.isEmpty()) {

--- a/wear/src/main/java/com/meatsack/motivator/sync/WatchVoteSender.kt
+++ b/wear/src/main/java/com/meatsack/motivator/sync/WatchVoteSender.kt
@@ -33,24 +33,26 @@ class WatchVoteSender(private val context: Context) {
     }
 
     suspend fun syncVotesToPhone(): VoteSyncResult {
-        val snapshots = AppDatabase.getDatabase(context).messageDao().getVotedMessages()
-            .take(SyncChannel.MAX_VOTE_ROWS)
-            .map { VoteSnapshot(it.id, it.votesUp, it.votesDown) }
-
-        if (snapshots.isEmpty()) {
-            Log.d(TAG, "No votes to sync")
-            return VoteSyncResult.NoVotes
-        }
-
-        val request = PutDataMapRequest.create(SyncChannel.PATH_VOTES).apply {
-            dataMap.putString(SyncChannel.KEY_VOTE_DATA, VoteSyncSerializer.serialize(snapshots))
-            dataMap.putLong(SyncChannel.KEY_TIMESTAMP, System.currentTimeMillis())
-        }.asPutDataRequest().setUrgent()
-
+        // The DB read is inside the failure boundary so every non-cancellation
+        // failure comes back as Failed — callers can rely on the result, not a throw.
         return try {
-            Wearable.getDataClient(context).putDataItem(request).await()
-            Log.d(TAG, "Synced ${snapshots.size} vote rows to phone")
-            VoteSyncResult.Success(snapshots.size)
+            val snapshots = AppDatabase.getDatabase(context).messageDao().getVotedMessages()
+                .take(SyncChannel.MAX_VOTE_ROWS)
+                .map { VoteSnapshot(it.id, it.votesUp, it.votesDown) }
+
+            if (snapshots.isEmpty()) {
+                Log.d(TAG, "No votes to sync")
+                VoteSyncResult.NoVotes
+            } else {
+                val request = PutDataMapRequest.create(SyncChannel.PATH_VOTES).apply {
+                    dataMap.putString(SyncChannel.KEY_VOTE_DATA, VoteSyncSerializer.serialize(snapshots))
+                    dataMap.putLong(SyncChannel.KEY_TIMESTAMP, System.currentTimeMillis())
+                }.asPutDataRequest().setUrgent()
+
+                Wearable.getDataClient(context).putDataItem(request).await()
+                Log.d(TAG, "Synced ${snapshots.size} vote rows to phone")
+                VoteSyncResult.Success(snapshots.size)
+            }
         } catch (ce: CancellationException) {
             // Don't absorb cancellation — propagating it keeps structured concurrency honest.
             throw ce

--- a/wear/src/main/java/com/meatsack/motivator/sync/WatchVoteSender.kt
+++ b/wear/src/main/java/com/meatsack/motivator/sync/WatchVoteSender.kt
@@ -1,0 +1,61 @@
+package com.meatsack.motivator.sync
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import com.meatsack.shared.db.AppDatabase
+import com.meatsack.shared.sync.SyncChannel
+import com.meatsack.shared.sync.VoteSnapshot
+import com.meatsack.shared.sync.VoteSyncSerializer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Outcome of a vote back-sync. Mirrors PhoneSyncSender.SyncResult so callers can
+ * distinguish "nothing to send" from a real failure.
+ */
+sealed class VoteSyncResult {
+    data class Success(val count: Int) : VoteSyncResult()
+    data object NoVotes : VoteSyncResult()
+    data class Failed(val error: Throwable) : VoteSyncResult()
+}
+
+/**
+ * Pushes the watch's current vote counts to the phone over the /votes Data Layer
+ * channel. The reverse of PhoneSyncSender's forward (/messages) pipe. Absolute
+ * counts keyed by message id, with a timestamp so every vote propagates.
+ */
+class WatchVoteSender(private val context: Context) {
+
+    companion object {
+        private const val TAG = "WatchVoteSender"
+    }
+
+    suspend fun syncVotesToPhone(): VoteSyncResult {
+        val snapshots = AppDatabase.getDatabase(context).messageDao().getVotedMessages()
+            .map { VoteSnapshot(it.id, it.votesUp, it.votesDown) }
+
+        if (snapshots.isEmpty()) {
+            Log.d(TAG, "No votes to sync")
+            return VoteSyncResult.NoVotes
+        }
+
+        val request = PutDataMapRequest.create(SyncChannel.PATH_VOTES).apply {
+            dataMap.putString(SyncChannel.KEY_VOTE_DATA, VoteSyncSerializer.serialize(snapshots))
+            dataMap.putLong(SyncChannel.KEY_TIMESTAMP, System.currentTimeMillis())
+        }.asPutDataRequest().setUrgent()
+
+        return try {
+            Wearable.getDataClient(context).putDataItem(request).await()
+            Log.d(TAG, "Synced ${snapshots.size} vote rows to phone")
+            VoteSyncResult.Success(snapshots.size)
+        } catch (ce: CancellationException) {
+            // Don't absorb cancellation — propagating it keeps structured concurrency honest.
+            throw ce
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to sync votes", e)
+            VoteSyncResult.Failed(e)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Watch votes now flow back to the phone Library via a new `/votes` Wear Data Layer channel — the reverse of the existing phone→watch `/messages` pipe.

- After a 👍/👎 on the watch, `WatchVoteSender` pushes the watch's current vote counts (absolute, per message id) as a `/votes` DataItem.
- A new phone-side `PhoneVoteReceiver` (`WearableListenerService`, the phone's first) applies them via `MessageDao.setVotes`.
- The phone Library is unchanged — `getAllMessagesFlow()` is reactive, so counts refresh live.

**Absolute, not deltas:** the watch sends current counts; the phone *sets* them → idempotent under Data Layer redelivery. `KEY_TIMESTAMP` ensures a revert-to-prior-count still propagates.

**id-match invariant:** back-sync keys on message id, valid because every message is born on the phone (identical seed order → matching ids; AI/custom created on phone then synced down). The watch never mints ids.

**Eventual consistency:** votes originate only on the watch (the authority); back-sync keeps the phone current so the manual "Sync to Watch" carries accurate counts. The sub-second vote-then-sync race self-heals.

## Commits
1. `VoteSyncSerializer` (pure, unit-tested) for the `/votes` channel
2. `/votes` channel constants + `getVotedMessages`/`setVotes` DAO
3. `WatchVoteSender` (mirrors `PhoneSyncSender`; adds `kotlinx-coroutines-play-services` to wear, which had never *sent* a DataItem)
4. Fire the back-sync after each vote in `InsultActivity` (write-then-sync, same coroutine)
5. `PhoneVoteReceiver` + manifest registration

## Test Plan
- [x] `./gradlew build` — all modules compile, lint clean, full unit suite passes
- [x] `VoteSyncSerializerTest` (round-trip, empty, drop-malformed)
- [x] Static round-trip traced end-to-end (holistic review): matching path/keys, shared serializer, write-before-read ordering, absolute idempotent `setVotes`, reactive Library, intact id-match invariant; forward pipe untouched
- [x] `PhoneVoteReceiver` confirmed registered on the phone with the `/votes` path filter (`dumpsys package`)
- [ ] **Live vote round-trip** — not triggerable on the emulator (`InsultActivity` is non-exported, and synthetic emulator steps prevent natural inactivity). The `/votes` transport is the same Wear Data Layer mechanism already verified working for `/settings`. Best confirmed on the physical SM-L320, where a real 👍 can be tapped.

## Notes
- The orphaned `VoteReceiver` (dead notification-action handler) is intentionally not wired into back-sync.
- No phone UI change — the Library already renders the counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)