### PR TITLE
Fix Sync-to-Watch crash on an over-length insult

### DIFF
--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSyncSender.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneSyncSender.kt
@@ -51,12 +51,15 @@ class PhoneSyncSender(private val context: Context) {
             return SyncResult.NoMessages
         }
 
-        val request = PutDataMapRequest.create(SyncChannel.PATH_MESSAGES).apply {
-            dataMap.putString(SyncChannel.KEY_MESSAGE_DATA, MessageSerializer.serialize(messages))
-            dataMap.putLong(SyncChannel.KEY_TIMESTAMP, System.currentTimeMillis())
-        }.asPutDataRequest().setUrgent()
-
+        // serialize() is inside the try: MessageSerializer.require()s text within limits
+        // and free of the '|'/newline separators, throwing IllegalArgumentException on a
+        // bad message. Building the request here (not before the try) means one malformed
+        // message yields SyncResult.Failed for the UI to report — not an app crash.
         return try {
+            val request = PutDataMapRequest.create(SyncChannel.PATH_MESSAGES).apply {
+                dataMap.putString(SyncChannel.KEY_MESSAGE_DATA, MessageSerializer.serialize(messages))
+                dataMap.putLong(SyncChannel.KEY_TIMESTAMP, System.currentTimeMillis())
+            }.asPutDataRequest().setUrgent()
             Wearable.getDataClient(context).putDataItem(request).await()
             Log.d(TAG, "Synced ${messages.size} messages to watch")
             SyncResult.Success(messages.size)

--- a/shared/src/main/assets/insults.json
+++ b/shared/src/main/assets/insults.json
@@ -33,7 +33,7 @@
   { "text": "You're a weakness-worshipping fraud. Your body is giving up on you because YOU gave up first.(L3)", "trigger": "INACTIVITY", "level": "NUCLEAR", "tone": "FULL_SEND" },
   { "text": "You soft-bellied comfort addict. 90 minutes. Your muscles scream; your excuses drown them out.(L3)", "trigger": "INACTIVITY", "level": "NUCLEAR", "tone": "FULL_SEND" },
   { "text": "GET UP, you osteopenic waste of a skeleton. 90 goddamn minutes.(L3)", "trigger": "INACTIVITY", "level": "NUCLEAR", "tone": "FULL_SEND" },
-  { "text": "Your bones are turning to chalk while you sit there, you pathetic snooze-button-hitting disgrace.(L3)", "trigger": "INACTIVITY", "level": "NUCLEAR", "tone": "FULL_SEND" },
+  { "text": "Your bones are turning to chalk while you sit there, you snooze-button-hitting disgrace.(L3)", "trigger": "INACTIVITY", "level": "NUCLEAR", "tone": "FULL_SEND" },
   { "text": "You potential-wasting coward. 90 minutes of choosing to be weak.(L3)", "trigger": "INACTIVITY", "level": "NUCLEAR", "tone": "FULL_SEND" },
 
   { "text": "Your ancestors survived wars and you can't walk to the kitchen.(L3 WS)", "trigger": "INACTIVITY", "level": "NUCLEAR", "tone": "WORK_SAFE" },

--- a/shared/src/test/java/com/meatsack/shared/data/InsultLoaderFileTest.kt
+++ b/shared/src/test/java/com/meatsack/shared/data/InsultLoaderFileTest.kt
@@ -1,8 +1,10 @@
 package com.meatsack.shared.data
 
 import com.meatsack.shared.constants.EscalationLevel
+import com.meatsack.shared.constants.MessageLimits
 import com.meatsack.shared.constants.MessageSource
 import com.meatsack.shared.constants.TriggerType
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -28,6 +30,24 @@ class InsultLoaderFileTest {
     @Test
     fun bundledFile_allRecordsArePreWritten() {
         assertTrue(bundledInsults().all { it.source == MessageSource.PRE_WRITTEN })
+    }
+
+    @Test
+    fun bundledFile_everyTextSerializable() {
+        // Sync serializes every active message via MessageSerializer, which rejects
+        // text over MAX_MESSAGE_TEXT_LENGTH or containing the '|'/newline field/line
+        // separators (a require() that crashes the caller). A bundled insult that
+        // violates these would seed fine but blow up "Sync to Watch" — guard it here
+        // so a bad edit fails CI instead of the app.
+        bundledInsults().forEach { m ->
+            assertTrue(
+                "insult exceeds ${MessageLimits.MAX_MESSAGE_TEXT_LENGTH} chars " +
+                    "(len=${m.text.length}): ${m.text}",
+                m.text.length <= MessageLimits.MAX_MESSAGE_TEXT_LENGTH,
+            )
+            assertFalse("insult contains '|': ${m.text}", m.text.contains("|"))
+            assertFalse("insult contains a newline: ${m.text}", m.text.contains("\n"))
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

The phone app crashed every time "Sync to Watch" was pressed (reproduced on a physical Moto G75; three identical fatals in the crash buffer).

## Root cause

`MessageSerializer.serialize` enforces `MessageLimits.MAX_MESSAGE_TEXT_LENGTH = 100` with a `require()` that throws. The bundled `insults.json` had one record (INACTIVITY / NUCLEAR) at **101 chars** — the `(L3)` marker tipped it over. `PhoneSyncSender.syncMessagesToWatch` called `serialize()` **outside** its `try/catch`, so the throw propagated uncaught and crashed the app.

Two latent gaps let this happen and turn fatal:
- `InsultLoaderFileTest` checks buckets / non-empty / PRE_WRITTEN but **not** length, so the over-long edit shipped through CI in #46 (which had dropped the exact-count assertion).
- `serialize()` sat outside the caller's error handling, so one bad message took down the whole app instead of failing gracefully.

## Fix (A + B + C)

- **A — data:** trim the offending insult to ≤100 chars (`insults.json`).
- **B — CI guard:** `InsultLoaderFileTest.bundledFile_everyTextSerializable` asserts every bundled insult is within `MAX_MESSAGE_TEXT_LENGTH` and free of `|`/newline. This is the failing test (red on the 101-char record) that pins the root cause.
- **C — robustness:** build the DataItem (incl. `serialize()`) inside the `try/catch` so a malformed message returns `SyncResult.Failed` for the UI to report, instead of crashing.

## Verification

- `:shared:testDebugUnitTest` green (new guard test red before A, green after).
- On the physical phone: reinstalled, re-seeded from corrected `insults.json` (DB now 55 rows, longest 98, 0 over limit), tapped **Sync to Watch** → no crash, log shows `Synced 55 messages to watch`.

## Note

`PhoneSyncSender` isn't unit-tested for C because it calls `AppDatabase`/`Wearable` statics directly (not injectable like `PhoneSettingsSyncer`). A SettingsSyncer-style refactor to cover it is a reasonable follow-up, out of scope for this crash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)