### PR TITLE
feat(debug): on-device diagnostics pipe (retained dev tool)

### DIFF
--- a/docs/debug/triggering-investigation.md
+++ b/docs/debug/triggering-investigation.md
@@ -1,0 +1,199 @@
+# Triggering / escalation bug — investigation + debug-page plan
+
+**Status:** Phase 1 (root-cause investigation) done from code reading. **Debug instrumentation
+built** (2026-07-01, branch `fix/triggering-diagnostics`) — option A (full phone Debug screen),
+evidence-first (no behavior fix yet). Builds + unit tests green; **awaiting install on the
+physical devices, then a day of on-device evidence before fixing.**
+
+---
+
+## What was built (the diagnostics pipe)
+
+Temporary, clearly marked "remove with the rest of the diagnostics pipe". Mirrors the existing
+`/votes` back-sync pipe.
+
+- **shared**
+  - `sync/SyncChannel.kt` — `PATH_DIAGNOSTICS="/diagnostics"`, `KEY_DIAG_DATA`, `MAX_DIAG_ROWS=400`
+    (wire window; sized < 100 KB DataItem limit).
+  - `sync/DiagnosticsSerializer.kt` — newline wire format (+ test).
+  - `diagnostics/DiagnosticsLineStore.kt` — pure-JVM persistent capped line buffer + `merge()`
+    (overlap-merge of sliding windows). Per-path interned-string lock for cross-instance safety
+    (+ test).
+- **wear**
+  - `MovementDetector.debugSnapshot()` → `MovementSnapshot` (idleMin, winSteps, winAge, lastTotal).
+  - `diagnostics/WatchDiagnostics.kt` — timestamps + appends to `filesDir/watch_diagnostics.log`
+    (survives service/process kills → catches H2).
+  - `HealthTracker` — optional `WatchDiagnostics`; logs each `STEP` update.
+  - `sync/WatchDiagnosticsSender.kt` — pushes recent window to phone over `/diagnostics`.
+  - `MeatsackWearService` — logs `LIFECYCLE onCreate/onStartCommand/onDestroy`, logs **every poll**
+    (`POLL hour=.. inWindow=.. idleMin=.. winSteps=.. total=.. move=.. -> SKIP(...)|FIRE level=..`),
+    and pushes to phone each poll. **Triggering behavior deliberately unchanged.**
+- **mobile**
+  - `sync/PhoneDiagnostics.kt` + `sync/PhoneDiagnosticsReceiver.kt` (registered in manifest) —
+    overlap-merges pushes into `filesDir/phone_diagnostics.log` (cap 10 000).
+  - `ui/debug/DebugViewModel.kt` + `ui/debug/DebugScreen.kt` — newest-first monospace log with
+    Refresh / Clear / Share. Reached via a "🐛 Trigger debug log" button at the bottom of Settings
+    (route `debug` in `NavGraph`).
+
+### How to read the log (what each hypothesis looks like)
+- **H1 (7am level-4 nuke):** the overnight `POLL` lines show `idleMin` climbing into the hundreds
+  while `inWindow=false`; the first `inWindow=true` poll at ~7am shows a huge `idleMin` → `FIRE
+  level=4`. Confirms idle clock is *not* frozen overnight, only delivery is gated.
+- **H2 (silent all day):** look for `LIFECYCLE onCreate` lines **without** a matching prior
+  `onDestroy`, or bursts of them, during the day — each resets `idleMin` back near 0, so it never
+  reaches the threshold. (Secondary: `STEP` lines with large deltas tripping `move=true` resets;
+  or `POLL` showing a wrong `thr=`/window from stale synced settings.)
+
+### Install (blocked on devices being connected)
+```bash
+adb -s ZY22KS3ML2 install -r mobile/build/outputs/apk/debug/mobile-debug.apk   # phone (moto g75)
+adb -s <watch-id> install -r wear/build/outputs/apk/debug/wear-debug.apk        # watch (SM-L320, wireless adb)
+```
+Then open the watch app (grant ACTIVITY_RECOGNITION) so the service + polling start; open the phone
+Settings → 🐛 Trigger debug log → Refresh.
+
+---
+
+## Symptoms (reported from the physical Galaxy Watch)
+
+1. **No insults all of "yesterday"** even with the inactivity window set to 10 min and the
+   movement threshold set to 400 steps, and even after adjusting those throughout the day.
+2. **A level 4 (EXISTENTIAL) insult fired first thing at ~7am today** — no escalation ramp,
+   straight to max.
+
+Cannot reproduce on the emulator (emulator emits a synthetic ~2 steps/sec stream), so we need
+on-device instrumentation.
+
+---
+
+## How triggering actually works (all on the **watch** / `wear` module)
+
+`MeatsackWearService` (`wear/.../MeatsackWearService.kt`) runs a foreground service, polls every
+60s → `checkInactivity()` (lines ~109–147):
+
+1. `if (!ActiveWindow.contains(hour, activeHoursStart, activeHoursEnd)) return`
+   — outside active hours (default 7–22) it **returns early**; comment says escalation is
+   "left frozen (not advanced, not reset)".
+2. `minutesIdle = healthTracker.getMinutesSinceLastMovement()`
+   — = `(now - lastMovementTimestamp) / 60000`, i.e. **real wall-clock** (see `MovementDetector`).
+3. `if (healthTracker.hasSignificantMovement()) { escalationManager.onMovementDetected(); return }`
+4. `if (!escalationManager.shouldTrigger(minutesIdle)) return`
+5. fire: `level = calculateLevel(minutesIdle)`, deliver notification.
+
+**`EscalationManager`** (`wear/.../escalation/EscalationManager.kt`):
+- `calculateLevel(minutesIdle)`: `minutesPast = max(0, minutesIdle - threshold)`,
+  `escalations = minutesPast / 30`; `>=3 EXISTENTIAL, >=2 NUCLEAR, >=1 SAVAGE, else AGGRESSIVE`.
+- `shouldTrigger`: fires when `minutesIdle >= threshold` and (first fire OR
+  `minutesIdle - lastFiredAtIdle >= 30`).
+- **All state is in-memory**: `lastFiredAtIdle`, `_currentLevel`, `isActive`, `inactivityStartTime`.
+
+**`MovementDetector`** (`wear/.../health/MovementDetector.kt`):
+- `lastMovementTimestamp` and `windowStartTimestamp` initialised to `now()` **at construction**.
+- `onStepTotal(currentTotal)` (called only when a STEPS_DAILY passive datapoint arrives):
+  computes delta from cumulative total, tumbling window (`windowMs = inactivityThreshold min`),
+  `stepsInCurrentWindow += delta`; if `>= movementStepThreshold` → `lastMovementTimestamp = now`,
+  reset window. Window only tumbles **inside `onStepTotal`** (i.e. driven by callback cadence).
+- `minutesSinceLastMovement()` = `(now() - lastMovementTimestamp)/60000`.
+
+**Lifecycle:** `MeatsackWearService.onCreate` constructs a fresh `HealthTracker` →
+fresh `MovementDetector` (so `lastMovementTimestamp = now()`) and a fresh `EscalationManager`.
+Service is `START_STICKY`. **Any service/process recreate resets all idle + escalation state.**
+
+---
+
+## Hypotheses
+
+### H1 — "Level 4 at 7am" — HIGH confidence (from code alone)
+The active-hours gate skips *delivery* overnight, but `minutesIdle` is wall-clock and
+`lastMovementTimestamp` does not advance while you sleep. At 7:00 the first in-window poll sees
+`minutesIdle ≈ 540` (since ~last night's last movement) → `(540-10)/30 = 17` escalations →
+**EXISTENTIAL fires instantly**. The "frozen" comment is wrong: the idle clock keeps running
+through the inactive overnight window; only *delivery* is gated, not the measurement.
+
+**Likely fix (after evidence):** when re-entering the active window (or when the gap since last
+movement spans outside active hours), reset/clamp the idle baseline + escalation so the ramp
+starts fresh at the start of the day. Candidate: on the first in-window poll after being out of
+window, call `onMovementDetected()` (or rebaseline `lastMovementTimestamp`) so escalation begins
+at AGGRESSIVE.
+
+### H2 — "No insults all day" — needs on-device evidence (multiple candidates)
+State is in-memory only. Candidates:
+- **(a) Service kills/restarts (Samsung/Wear battery optimization — see README known limits).**
+  Each recreate resets `lastMovementTimestamp = now()`, so `minutesIdle` never climbs to the
+  threshold → nothing fires. Strongest candidate.
+- (b) Batched/sparse STEPS_DAILY deltas landing in a fresh tumbling window and tripping false
+  "movement" (>= 400 in one batch) → idle keeps resetting.
+- (c) Synced settings not actually reaching the watch (`WatchSettingsCache` stale) → wrong
+  threshold/window in effect.
+
+H1 + H2 are consistent: overnight on a charger the service runs stably → idle accumulates →
+level 4 at 7am; during the day on-wrist, battery opt churns the service → idle resets → silence.
+
+---
+
+## Plan: temporary debug instrumentation (Phase-1 evidence gathering)
+
+**Key requirement:** the log MUST persist across service restarts (write each event to a file on
+the watch immediately) — otherwise it can't catch H2 (a dying service takes its in-memory log
+with it).
+
+**Watch** — a `DiagnosticsLog` (persistent, capped ring buffer in a file under `filesDir`) records,
+with timestamps:
+- Service lifecycle: `onCreate` / `onStartCommand` / `onDestroy` (← reveals kills/restarts = H2)
+- Every 60s poll: hour, in-active-window?, `minutesIdle`, steps-in-window, total steps today,
+  `hasSignificantMovement`, `shouldTrigger`, computed level, and **fired or skip-reason**
+- Every step update (`onStepTotal`): cumulative total, delta, window age, steps-in-window
+- Every fire: level, trigger, idle
+  (Will need to expose `MovementDetector` internal state via a small `debugSnapshot()`.)
+
+**Sync** — new `/diagnostics` Data Layer channel mirroring the existing `/votes` pipe
+(`WatchVoteSender` → `PhoneVoteReceiver`; constants in `shared/.../sync/SyncChannel.kt`).
+Watch pushes recent lines → phone each poll.
+
+**Phone** — `PhoneDiagnosticsReceiver` (WearableListenerService) stores received lines; a **Debug
+screen** reached from a button at the bottom of Settings shows the log newest-first, monospace,
+with **Refresh / Clear / Share**.
+
+### Reuse / reference points
+- Sync channel constants: `shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt`
+  (`PATH_VOTES`, `KEY_VOTE_DATA`, `KEY_TIMESTAMP`, `MAX_VOTE_ROWS`). Add `PATH_DIAGNOSTICS`,
+  `KEY_DIAG_DATA`, `MAX_DIAG_ROWS`.
+- Sender pattern: `wear/.../sync/WatchVoteSender.kt`.
+- Receiver pattern: `mobile/.../sync/PhoneVoteReceiver.kt` (and registered as a
+  `WearableListenerService` in the mobile manifest — check `mobile/src/main/AndroidManifest.xml`).
+- Phone nav/screens: `mobile/.../ui/navigation/NavGraph.kt`, `ui/settings/SettingsScreen.kt`.
+- Serializer pattern (`|` + newline): `shared/.../sync/VoteSyncSerializer.kt` — though for
+  diagnostics, preformatted single-line strings (timestamp + text) joined by `\n` are simplest.
+
+---
+
+## DECISIONS (resolved 2026-07-01 on resume)
+
+1. **Scope of the debug tool: (A) Full** — watch persistent log + `/diagnostics` sync +
+   phone Debug screen (refresh/clear/share). Reinstall BOTH watch and phone apps.
+2. **H1 fix timing: (A) Evidence-first** — build debug tooling only now; fix H1 + H2 after
+   a day of on-device logs confirms the mechanism. No escalation/idle behavior change yet.
+
+---
+
+## Context / where things stand
+- On `main` (clean working tree apart from pre-existing untracked: `.agents/`, `skills-lock.json`,
+  `docs/superpowers/plans/2026-06-25-externalize-insults.md`).
+- Recently merged: PR #50 (insults archive), #51 (Vitals redesign), #52 (Bubblegum theme).
+- Phone app (debug build) is installed and running on the physical phone (moto g75, `ZY22KS3ML2`).
+- Emulator was shut down.
+- Suspect recent commits that touched movement/escalation: `f4f2fde` (floor movement window >=1;
+  re-arm + live window), `cdaa41c`/`384c701` (configurable movement step threshold). Worth a
+  `git log -p` on `MovementDetector.kt` / `EscalationManager.kt` when resuming.
+
+## Resume checklist
+1. Re-read this file. Decisions resolved (A / evidence-first); tooling built on
+   `fix/triggering-diagnostics`; builds + unit tests green.
+2. **Next:** connect the physical phone + watch (wireless adb), run the two install commands above,
+   open the watch app (grant ACTIVITY_RECOGNITION), confirm the phone Debug screen receives lines.
+3. Let it run through an overnight + a normal day. Read the log per "How to read the log" above to
+   confirm H1 and identify which H2 candidate is real.
+4. Only then write the fix (Phase 4), on its own branch, with a failing test reproducing the
+   confirmed root cause first.
+5. Commit the diagnostics on `fix/triggering-diagnostics`; PR into `main` (or hold until the fix
+   lands on top, then PR together). Never commit to `main`.

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -35,8 +35,8 @@
             </intent-filter>
         </service>
 
-        <!-- Temporary triggering-diagnostics receiver. See
-             docs/debug/triggering-investigation.md. Remove with the rest of the pipe. -->
+        <!-- On-device diagnostics receiver (retained dev-debugging tool). See
+             docs/debug/triggering-investigation.md. -->
         <service
             android:name=".sync.PhoneDiagnosticsReceiver"
             android:exported="true">

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -35,6 +35,20 @@
             </intent-filter>
         </service>
 
+        <!-- Temporary triggering-diagnostics receiver. See
+             docs/debug/triggering-investigation.md. Remove with the rest of the pipe. -->
+        <service
+            android:name=".sync.PhoneDiagnosticsReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+                <data
+                    android:scheme="wear"
+                    android:host="*"
+                    android:pathPrefix="/diagnostics" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneDiagnostics.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneDiagnostics.kt
@@ -10,7 +10,7 @@ import java.io.File
  * file and the Debug screen reads it back. A larger cap than the wire window so the phone
  * accumulates several days of the watch's history even though each push is bounded.
  *
- * Temporary — delete with the rest of the diagnostics pipe.
+ * Retained on-device dev/diagnostics tool (see docs/debug/triggering-investigation.md).
  */
 object PhoneDiagnostics {
     const val FILE_NAME = "phone_diagnostics.log"

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneDiagnostics.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneDiagnostics.kt
@@ -1,0 +1,21 @@
+package com.meatsack.motivator.mobile.sync
+
+import android.content.Context
+import com.meatsack.shared.diagnostics.DiagnosticsLineStore
+import java.io.File
+
+/**
+ * Phone-side home for the watch's triggering diagnostics
+ * (docs/debug/triggering-investigation.md). The receiver folds each pushed window into this
+ * file and the Debug screen reads it back. A larger cap than the wire window so the phone
+ * accumulates several days of the watch's history even though each push is bounded.
+ *
+ * Temporary — delete with the rest of the diagnostics pipe.
+ */
+object PhoneDiagnostics {
+    const val FILE_NAME = "phone_diagnostics.log"
+    const val MAX_ROWS = 10_000
+
+    fun store(context: Context): DiagnosticsLineStore =
+        DiagnosticsLineStore(File(context.filesDir, FILE_NAME), MAX_ROWS)
+}

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneDiagnosticsReceiver.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneDiagnosticsReceiver.kt
@@ -10,10 +10,10 @@ import com.meatsack.shared.sync.SyncChannel
 import kotlinx.coroutines.launch
 
 /**
- * Receives the watch's temporary `/diagnostics` pushes and overlap-merges each window into
+ * Receives the watch's `/diagnostics` pushes and overlap-merges each window into
  * the phone's persistent log (read by the Debug screen). Mirrors [PhoneVoteReceiver].
  *
- * Temporary — delete with the rest of the diagnostics pipe
+ * Retained on-device dev/diagnostics tool
  * (docs/debug/triggering-investigation.md).
  */
 class PhoneDiagnosticsReceiver : WearableListenerService() {

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneDiagnosticsReceiver.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/sync/PhoneDiagnosticsReceiver.kt
@@ -1,0 +1,46 @@
+package com.meatsack.motivator.mobile.sync
+
+import android.util.Log
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.WearableListenerService
+import com.meatsack.motivator.mobile.MeatsackMobileApp
+import com.meatsack.shared.sync.DiagnosticsSerializer
+import com.meatsack.shared.sync.SyncChannel
+import kotlinx.coroutines.launch
+
+/**
+ * Receives the watch's temporary `/diagnostics` pushes and overlap-merges each window into
+ * the phone's persistent log (read by the Debug screen). Mirrors [PhoneVoteReceiver].
+ *
+ * Temporary — delete with the rest of the diagnostics pipe
+ * (docs/debug/triggering-investigation.md).
+ */
+class PhoneDiagnosticsReceiver : WearableListenerService() {
+
+    companion object {
+        private const val TAG = "PhoneDiagnosticsRecv"
+    }
+
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        dataEvents.forEach { event ->
+            if (event.dataItem.uri.path != SyncChannel.PATH_DIAGNOSTICS) return@forEach
+            val sourceNode = event.dataItem.uri.host
+            val dataMap = DataMapItem.fromDataItem(event.dataItem).dataMap
+            val serialized = dataMap.getString(SyncChannel.KEY_DIAG_DATA)
+            if (serialized == null) {
+                Log.w(TAG, "Missing ${SyncChannel.KEY_DIAG_DATA} from node=$sourceNode")
+                return@forEach
+            }
+
+            val lines = DiagnosticsSerializer.deserialize(serialized)
+            if (lines.isEmpty()) return@forEach
+
+            val scope = (applicationContext as MeatsackMobileApp).applicationScope
+            scope.launch {
+                PhoneDiagnostics.store(applicationContext).appendMerging(lines)
+                Log.d(TAG, "Merged ${lines.size} diagnostic lines from node=$sourceNode")
+            }
+        }
+    }
+}

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/debug/DebugScreen.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/debug/DebugScreen.kt
@@ -1,0 +1,105 @@
+package com.meatsack.motivator.mobile.ui.debug
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+/**
+ * Temporary Debug screen for the triggering investigation
+ * (docs/debug/triggering-investigation.md). Shows the watch's diagnostic log newest-first in
+ * a monospace list, with Refresh / Clear / Share. Reached from the bottom of Settings.
+ *
+ * Delete with the rest of the diagnostics pipe once the bug is fixed.
+ */
+@Composable
+fun DebugScreen(
+    onBack: () -> Unit,
+    viewModel: DebugViewModel = viewModel(),
+) {
+    val lines by viewModel.lines.collectAsState()
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        Text(
+            "TRIGGER DEBUG LOG",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "${lines.size} lines · newest first · pushed from the watch each poll",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(12.dp))
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = { viewModel.refresh() }) { Text("Refresh") }
+            OutlinedButton(
+                onClick = {
+                    val share = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        // Share oldest-first so the exported log reads top-to-bottom in time.
+                        putExtra(Intent.EXTRA_TEXT, lines.asReversed().joinToString("\n"))
+                    }
+                    context.startActivity(Intent.createChooser(share, "Share diagnostics"))
+                },
+                enabled = lines.isNotEmpty(),
+            ) { Text("Share") }
+            Spacer(Modifier.weight(1f))
+            TextButton(onClick = { viewModel.clear() }) { Text("Clear") }
+        }
+        Spacer(Modifier.height(8.dp))
+        TextButton(onClick = onBack) { Text("← Back") }
+        Spacer(Modifier.height(8.dp))
+
+        if (lines.isEmpty()) {
+            Text(
+                "No diagnostics received yet. Make sure the watch app is running and the " +
+                    "phone is paired, then tap Refresh.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                items(lines) { line ->
+                    Text(
+                        line,
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 11.sp,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 1.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/debug/DebugScreen.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/debug/DebugScreen.kt
@@ -27,11 +27,9 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 
 /**
- * Temporary Debug screen for the triggering investigation
- * (docs/debug/triggering-investigation.md). Shows the watch's diagnostic log newest-first in
- * a monospace list, with Refresh / Clear / Share. Reached from the bottom of Settings.
- *
- * Delete with the rest of the diagnostics pipe once the bug is fixed.
+ * On-device diagnostics Debug screen (retained dev tool). Shows the watch's diagnostic log
+ * newest-first in a monospace list, with Refresh / Clear / Share. Reached from the bottom of
+ * Settings. First built for docs/debug/triggering-investigation.md.
  */
 @Composable
 fun DebugScreen(

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/debug/DebugViewModel.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/debug/DebugViewModel.kt
@@ -11,11 +11,11 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 /**
- * Backs the temporary Debug screen: exposes the watch's diagnostic log (received over
+ * Backs the on-device diagnostics Debug screen: exposes the watch's diagnostic log (received over
  * `/diagnostics`) newest-first, with refresh and clear. Read on the IO dispatcher so file
  * access never blocks the main thread.
  *
- * Temporary — delete with the rest of the diagnostics pipe
+ * Retained on-device dev/diagnostics tool
  * (docs/debug/triggering-investigation.md).
  */
 class DebugViewModel(application: Application) : AndroidViewModel(application) {

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/debug/DebugViewModel.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/debug/DebugViewModel.kt
@@ -1,0 +1,44 @@
+package com.meatsack.motivator.mobile.ui.debug
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.meatsack.motivator.mobile.sync.PhoneDiagnostics
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Backs the temporary Debug screen: exposes the watch's diagnostic log (received over
+ * `/diagnostics`) newest-first, with refresh and clear. Read on the IO dispatcher so file
+ * access never blocks the main thread.
+ *
+ * Temporary — delete with the rest of the diagnostics pipe
+ * (docs/debug/triggering-investigation.md).
+ */
+class DebugViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val store = PhoneDiagnostics.store(application)
+
+    private val _lines = MutableStateFlow<List<String>>(emptyList())
+    val lines: StateFlow<List<String>> = _lines.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch(Dispatchers.IO) {
+            _lines.value = store.read().asReversed()
+        }
+    }
+
+    fun clear() {
+        viewModelScope.launch(Dispatchers.IO) {
+            store.clear()
+            _lines.value = emptyList()
+        }
+    }
+}

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/navigation/NavGraph.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/navigation/NavGraph.kt
@@ -26,7 +26,7 @@ import com.meatsack.motivator.mobile.ui.settings.SettingsScreen
 import com.meatsack.motivator.mobile.ui.theme.LocalThemeChoice
 import com.meatsack.motivator.mobile.ui.theme.ThemeChoice
 
-/** Route for the temporary diagnostics screen (not part of the bottom-nav [Screen] set). */
+/** Route for the on-device diagnostics screen (not part of the bottom-nav [Screen] set). */
 private const val DEBUG_ROUTE = "debug"
 
 enum class Screen(
@@ -93,7 +93,7 @@ fun MeatsackNavGraph() {
             composable(Screen.Settings.route) {
                 SettingsScreen(onOpenDebug = { navController.navigate(DEBUG_ROUTE) })
             }
-            // Temporary diagnostics screen — not a bottom-nav tab; reached from Settings.
+            // On-device diagnostics screen — not a bottom-nav tab; reached from Settings.
             // See docs/debug/triggering-investigation.md.
             composable(DEBUG_ROUTE) { DebugScreen(onBack = { navController.popBackStack() }) }
         }

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/navigation/NavGraph.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/navigation/NavGraph.kt
@@ -20,10 +20,14 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.meatsack.motivator.mobile.ui.debug.DebugScreen
 import com.meatsack.motivator.mobile.ui.library.LibraryScreen
 import com.meatsack.motivator.mobile.ui.settings.SettingsScreen
 import com.meatsack.motivator.mobile.ui.theme.LocalThemeChoice
 import com.meatsack.motivator.mobile.ui.theme.ThemeChoice
+
+/** Route for the temporary diagnostics screen (not part of the bottom-nav [Screen] set). */
+private const val DEBUG_ROUTE = "debug"
 
 enum class Screen(
     val route: String,
@@ -86,7 +90,12 @@ fun MeatsackNavGraph() {
             modifier = Modifier.padding(padding),
         ) {
             composable(Screen.Library.route) { LibraryScreen() }
-            composable(Screen.Settings.route) { SettingsScreen() }
+            composable(Screen.Settings.route) {
+                SettingsScreen(onOpenDebug = { navController.navigate(DEBUG_ROUTE) })
+            }
+            // Temporary diagnostics screen — not a bottom-nav tab; reached from Settings.
+            // See docs/debug/triggering-investigation.md.
+            composable(DEBUG_ROUTE) { DebugScreen(onBack = { navController.popBackStack() }) }
         }
     }
 }

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsScreen.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RangeSlider
 import androidx.compose.material3.RichTooltip
@@ -56,7 +57,10 @@ import com.meatsack.motivator.mobile.ui.theme.ThemeChoice
 import kotlinx.coroutines.launch
 
 @Composable
-fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
+fun SettingsScreen(
+    viewModel: SettingsViewModel = viewModel(),
+    onOpenDebug: () -> Unit = {},
+) {
     val stepGoal by viewModel.dailyStepGoal.collectAsState()
     val inactivityThreshold by viewModel.inactivityThreshold.collectAsState()
     val movementSteps by viewModel.movementStepThreshold.collectAsState()
@@ -282,6 +286,16 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
                 modifier = Modifier.width(140.dp),
             )
         }
+
+        // Temporary entry point to the triggering-diagnostics log. See
+        // docs/debug/triggering-investigation.md. Remove with the rest of the pipe.
+        Spacer(Modifier.height(24.dp))
+        HorizontalDivider(color = MaterialTheme.colorScheme.outline)
+        Spacer(Modifier.height(16.dp))
+        OutlinedButton(onClick = onOpenDebug, modifier = Modifier.fillMaxWidth()) {
+            Text("🐛 Trigger debug log")
+        }
+        Spacer(Modifier.height(16.dp))
     }
 }
 

--- a/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsScreen.kt
+++ b/mobile/src/main/java/com/meatsack/motivator/mobile/ui/settings/SettingsScreen.kt
@@ -287,8 +287,8 @@ fun SettingsScreen(
             )
         }
 
-        // Temporary entry point to the triggering-diagnostics log. See
-        // docs/debug/triggering-investigation.md. Remove with the rest of the pipe.
+        // Entry point to the on-device diagnostics log (retained dev tool). See
+        // docs/debug/triggering-investigation.md.
         Spacer(Modifier.height(24.dp))
         HorizontalDivider(color = MaterialTheme.colorScheme.outline)
         Spacer(Modifier.height(16.dp))

--- a/shared/src/main/java/com/meatsack/shared/diagnostics/DiagnosticsLineStore.kt
+++ b/shared/src/main/java/com/meatsack/shared/diagnostics/DiagnosticsLineStore.kt
@@ -9,8 +9,8 @@ import java.io.File
  * condition we need to catch (a watch service the OS keeps killing takes its *in-memory*
  * state with it, but not this file).
  *
- * Temporary scaffolding for the triggering investigation
- * (docs/debug/triggering-investigation.md). Remove with the rest of the diagnostics pipe.
+ * On-device diagnostics tool, first built for the triggering investigation
+ * (docs/debug/triggering-investigation.md). Retained as a standing dev-debugging aid — do not strip.
  *
  * Thread-safety: all file operations synchronize on a JVM-wide monitor keyed by the file's
  * absolute path (an interned String), so independent instances pointing at the same file —

--- a/shared/src/main/java/com/meatsack/shared/diagnostics/DiagnosticsLineStore.kt
+++ b/shared/src/main/java/com/meatsack/shared/diagnostics/DiagnosticsLineStore.kt
@@ -1,0 +1,80 @@
+package com.meatsack.shared.diagnostics
+
+import java.io.File
+
+/**
+ * A persistent, capped, newline-delimited line buffer backed by a single file. Pure JVM
+ * (no Android types) so it unit-tests on the plain JVM; production passes a file under
+ * `context.filesDir`. Critically the file survives process/service death — exactly the
+ * condition we need to catch (a watch service the OS keeps killing takes its *in-memory*
+ * state with it, but not this file).
+ *
+ * Temporary scaffolding for the triggering investigation
+ * (docs/debug/triggering-investigation.md). Remove with the rest of the diagnostics pipe.
+ *
+ * Thread-safety: all file operations synchronize on a JVM-wide monitor keyed by the file's
+ * absolute path (an interned String), so independent instances pointing at the same file —
+ * e.g. a WearableListenerService writing while a ViewModel reads — still serialize correctly.
+ */
+class DiagnosticsLineStore(
+    private val file: File,
+    private val maxRows: Int = DEFAULT_MAX_ROWS,
+) {
+    // Interned path → one canonical monitor per file across all instances in this process.
+    private val lock: Any = file.absolutePath.intern()
+
+    /** Append one line, then trim to the most recent [maxRows]. */
+    fun append(line: String) = synchronized(lock) {
+        writeUnlocked(readUnlocked() + line)
+    }
+
+    /**
+     * Merge an incoming ordered window into the stored history (see [merge]) and trim.
+     * Used by the phone receiver to fold each pushed window into the full record.
+     */
+    fun appendMerging(incoming: List<String>) = synchronized(lock) {
+        writeUnlocked(merge(readUnlocked(), incoming))
+    }
+
+    fun read(): List<String> = synchronized(lock) { readUnlocked() }
+
+    fun clear() = synchronized(lock) {
+        runCatching { if (file.exists()) file.delete() }
+    }
+
+    private fun readUnlocked(): List<String> =
+        runCatching {
+            if (!file.exists()) emptyList() else file.readText().split("\n").filter { it.isNotEmpty() }
+        }.getOrDefault(emptyList())
+
+    private fun writeUnlocked(lines: List<String>) {
+        val capped = if (lines.size > maxRows) lines.subList(lines.size - maxRows, lines.size) else lines
+        runCatching {
+            file.parentFile?.mkdirs()
+            file.writeText(capped.joinToString("\n"))
+        }
+    }
+
+    companion object {
+        const val DEFAULT_MAX_ROWS = 5000
+
+        /**
+         * Fold an [incoming] window of newer lines into [existing], assuming both are ordered
+         * and the windows overlap (the watch sends a sliding window each poll). Finds the
+         * longest suffix of [existing] that equals a prefix of [incoming] and appends only the
+         * non-overlapping remainder — so repeated overlapping pushes reconstruct the full,
+         * de-duplicated history. With no overlap it conservatively concatenates.
+         */
+        fun merge(existing: List<String>, incoming: List<String>): List<String> {
+            if (existing.isEmpty()) return incoming
+            if (incoming.isEmpty()) return existing
+            val maxK = minOf(existing.size, incoming.size)
+            for (k in maxK downTo 1) {
+                if (existing.subList(existing.size - k, existing.size) == incoming.subList(0, k)) {
+                    return existing + incoming.subList(k, incoming.size)
+                }
+            }
+            return existing + incoming
+        }
+    }
+}

--- a/shared/src/main/java/com/meatsack/shared/sync/DiagnosticsSerializer.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/DiagnosticsSerializer.kt
@@ -1,13 +1,13 @@
 package com.meatsack.shared.sync
 
 /**
- * Wire (de)serializer for the temporary `/diagnostics` Data Layer channel (watch → phone).
+ * Wire (de)serializer for the `/diagnostics` Data Layer channel (watch → phone).
  * Each diagnostic line is already a single preformatted string (timestamp + text); the
  * payload is just those lines joined by `\n`. Blank lines are dropped on the way back so a
  * trailing separator never materialises as an empty entry.
  *
- * Temporary — paired with the triggering investigation in
- * docs/debug/triggering-investigation.md. Remove with the rest of the diagnostics pipe.
+ * Part of the on-device diagnostics tool (see docs/debug/triggering-investigation.md).
+ * Retained as a standing dev-debugging aid — do not strip.
  */
 object DiagnosticsSerializer {
     private const val LINE_SEPARATOR = "\n"

--- a/shared/src/main/java/com/meatsack/shared/sync/DiagnosticsSerializer.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/DiagnosticsSerializer.kt
@@ -1,0 +1,19 @@
+package com.meatsack.shared.sync
+
+/**
+ * Wire (de)serializer for the temporary `/diagnostics` Data Layer channel (watch → phone).
+ * Each diagnostic line is already a single preformatted string (timestamp + text); the
+ * payload is just those lines joined by `\n`. Blank lines are dropped on the way back so a
+ * trailing separator never materialises as an empty entry.
+ *
+ * Temporary — paired with the triggering investigation in
+ * docs/debug/triggering-investigation.md. Remove with the rest of the diagnostics pipe.
+ */
+object DiagnosticsSerializer {
+    private const val LINE_SEPARATOR = "\n"
+
+    fun serialize(lines: List<String>): String = lines.joinToString(LINE_SEPARATOR)
+
+    fun deserialize(data: String): List<String> =
+        if (data.isEmpty()) emptyList() else data.split(LINE_SEPARATOR).filter { it.isNotEmpty() }
+}

--- a/shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt
@@ -20,8 +20,8 @@ object SyncChannel {
      */
     const val MAX_VOTE_ROWS = 2000
 
-    // --- Temporary triggering-diagnostics pipe (watch → phone). See
-    // docs/debug/triggering-investigation.md. Remove once the triggering bug is fixed.
+    // --- On-device diagnostics pipe (watch → phone), a retained dev-debugging tool. See
+    // docs/debug/triggering-investigation.md. Do not strip.
     const val PATH_DIAGNOSTICS = "/diagnostics"
     const val KEY_DIAG_DATA = "diag_data"
 

--- a/shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt
+++ b/shared/src/main/java/com/meatsack/shared/sync/SyncChannel.kt
@@ -19,4 +19,19 @@ object SyncChannel {
      * message count.
      */
     const val MAX_VOTE_ROWS = 2000
+
+    // --- Temporary triggering-diagnostics pipe (watch → phone). See
+    // docs/debug/triggering-investigation.md. Remove once the triggering bug is fixed.
+    const val PATH_DIAGNOSTICS = "/diagnostics"
+    const val KEY_DIAG_DATA = "diag_data"
+
+    /**
+     * Max diagnostic lines in one /diagnostics payload. The watch holds the full
+     * record on disk and only pushes the most recent [MAX_DIAG_ROWS] lines each poll;
+     * the phone overlap-merges successive windows into its full history. Sized so a
+     * worst-case payload (400 rows x ~180 chars ≈ 72 KB) stays under the ~100 KB
+     * DataItem limit while still overlapping consecutive 60 s polls by hundreds of
+     * lines (polls add only 1–3 lines), keeping the merge unambiguous.
+     */
+    const val MAX_DIAG_ROWS = 400
 }

--- a/shared/src/test/java/com/meatsack/shared/diagnostics/DiagnosticsLineStoreTest.kt
+++ b/shared/src/test/java/com/meatsack/shared/diagnostics/DiagnosticsLineStoreTest.kt
@@ -1,0 +1,60 @@
+package com.meatsack.shared.diagnostics
+
+import com.meatsack.shared.diagnostics.DiagnosticsLineStore.Companion.merge
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class DiagnosticsLineStoreTest {
+
+    private fun tempFile(): File =
+        File.createTempFile("diag", ".log").also {
+            it.deleteOnExit()
+            it.delete()
+        }
+
+    @Test fun append_thenRead_roundTrips() {
+        val store = DiagnosticsLineStore(tempFile())
+        store.append("one")
+        store.append("two")
+        assertEquals(listOf("one", "two"), store.read())
+    }
+
+    @Test fun read_missingFile_returnsEmpty() {
+        assertEquals(emptyList<String>(), DiagnosticsLineStore(tempFile()).read())
+    }
+
+    @Test fun append_capsToMaxRows_keepingNewest() {
+        val store = DiagnosticsLineStore(tempFile(), maxRows = 3)
+        (1..5).forEach { store.append("line$it") }
+        assertEquals(listOf("line3", "line4", "line5"), store.read())
+    }
+
+    @Test fun clear_removesAllLines() {
+        val store = DiagnosticsLineStore(tempFile())
+        store.append("x")
+        store.clear()
+        assertEquals(emptyList<String>(), store.read())
+    }
+
+    @Test fun appendMerging_overlappingWindows_reconstructFullHistory() {
+        val store = DiagnosticsLineStore(tempFile())
+        store.appendMerging(listOf("a", "b", "c"))
+        store.appendMerging(listOf("b", "c", "d")) // slides forward by one
+        store.appendMerging(listOf("c", "d", "e"))
+        assertEquals(listOf("a", "b", "c", "d", "e"), store.read())
+    }
+
+    @Test fun merge_emptyExisting_returnsIncoming() {
+        assertEquals(listOf("a", "b"), merge(emptyList(), listOf("a", "b")))
+    }
+
+    @Test fun merge_noOverlap_concatenates() {
+        // Defensive path: a gap (e.g. across a long outage) appends rather than dropping data.
+        assertEquals(listOf("a", "b", "x", "y"), merge(listOf("a", "b"), listOf("x", "y")))
+    }
+
+    @Test fun merge_fullDuplicateWindow_isIdempotent() {
+        assertEquals(listOf("a", "b", "c"), merge(listOf("a", "b", "c"), listOf("a", "b", "c")))
+    }
+}

--- a/shared/src/test/java/com/meatsack/shared/sync/DiagnosticsSerializerTest.kt
+++ b/shared/src/test/java/com/meatsack/shared/sync/DiagnosticsSerializerTest.kt
@@ -1,0 +1,35 @@
+package com.meatsack.shared.sync
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DiagnosticsSerializerTest {
+
+    @Test fun roundTrip_preservesLines() {
+        val lines = listOf("06-30 07:00:01 POLL idle=540", "06-30 07:00:01 FIRE level=4")
+        assertEquals(lines, DiagnosticsSerializer.deserialize(DiagnosticsSerializer.serialize(lines)))
+    }
+
+    @Test fun deserialize_emptyString_returnsEmptyList() {
+        assertEquals(emptyList<String>(), DiagnosticsSerializer.deserialize(""))
+    }
+
+    @Test fun serialize_emptyList_returnsEmptyString() {
+        assertEquals("", DiagnosticsSerializer.serialize(emptyList()))
+    }
+
+    @Test fun deserialize_dropsBlankLines() {
+        // A trailing separator (or stray blank) must not surface as an empty entry.
+        assertEquals(listOf("a", "b"), DiagnosticsSerializer.deserialize("a\nb\n"))
+    }
+
+    @Test fun maxDiagRows_worstCasePayload_underDataItemLimit() {
+        // Backs the sizing claim in SyncChannel.MAX_DIAG_ROWS: a full window of long lines
+        // stays well under the ~100 KB Data Layer DataItem limit.
+        val line = "X".repeat(180)
+        val lines = List(SyncChannel.MAX_DIAG_ROWS) { line }
+        val serialized = DiagnosticsSerializer.serialize(lines)
+        assertTrue("payload was ${serialized.length} chars", serialized.length < 100_000)
+    }
+}

--- a/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import com.meatsack.motivator.diagnostics.WatchDiagnostics
 import com.meatsack.motivator.escalation.EscalationManager
 import com.meatsack.motivator.health.HealthTracker
 import com.meatsack.motivator.messages.ActiveWindow
@@ -16,6 +17,7 @@ import com.meatsack.motivator.messages.MessageRepository
 import com.meatsack.motivator.messages.ToneResolver
 import com.meatsack.motivator.notification.InsultNotificationService
 import com.meatsack.motivator.settings.WatchSettingsCache
+import com.meatsack.motivator.sync.WatchDiagnosticsSender
 import com.meatsack.motivator.trigger.TriggerScheduler
 import com.meatsack.shared.constants.TriggerType
 import com.meatsack.shared.db.AppDatabase
@@ -36,6 +38,10 @@ class MeatsackWearService : Service() {
     private lateinit var notificationService: InsultNotificationService
     private lateinit var settings: WatchSettingsCache
 
+    // Temporary triggering diagnostics (docs/debug/triggering-investigation.md).
+    private lateinit var diagnostics: WatchDiagnostics
+    private lateinit var diagnosticsSender: WatchDiagnosticsSender
+
     private var pollingJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
@@ -52,14 +58,25 @@ class MeatsackWearService : Service() {
         super.onCreate()
         val db = AppDatabase.getDatabase(applicationContext)
         settings = WatchSettingsCache(applicationContext)
+        diagnostics = WatchDiagnostics.create(applicationContext)
+        diagnosticsSender = WatchDiagnosticsSender(applicationContext, diagnostics)
         healthTracker = HealthTracker(
             applicationContext,
             stepThresholdProvider = { settings.movementStepThreshold },
             windowMinutesProvider = { settings.inactivityThreshold },
+            diagnostics = diagnostics,
         )
         escalationManager = EscalationManager(thresholdProvider = { settings.inactivityThreshold })
         messageRepo = MessageRepository(db.messageDao())
         notificationService = InsultNotificationService(applicationContext)
+        // The most important line for hypothesis H2: an onCreate with no preceding onDestroy
+        // (or a burst of them) is the fingerprint of the OS killing and restarting the service,
+        // which resets all in-memory idle/escalation state.
+        diagnostics.log(
+            "LIFECYCLE onCreate thr=${settings.inactivityThreshold}min " +
+                "moveSteps=${settings.movementStepThreshold} " +
+                "active=${settings.activeHoursStart}-${settings.activeHoursEnd}",
+        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -69,11 +86,14 @@ class MeatsackWearService : Service() {
         scheduler.scheduleBehindPaceCheck(settings.behindPaceCheckHour)
         scheduler.scheduleEndOfDay(settings.activeHoursEnd)
         startPolling()
+        diagnostics.log("LIFECYCLE onStartCommand flags=$flags startId=$startId")
         Log.d(TAG, "meatsackMotivator service started. Watching you.")
         return START_STICKY
     }
 
     override fun onDestroy() {
+        // Log before tearing down the scope so the kill is recorded even on a clean shutdown.
+        diagnostics.log("LIFECYCLE onDestroy")
         pollingJob?.cancel()
         scope.cancel()
         healthTracker.stopTracking()
@@ -107,20 +127,36 @@ class MeatsackWearService : Service() {
     }
 
     private suspend fun checkInactivity() {
+        // NOTE: this method's *triggering behavior* is deliberately unchanged — the diagnostics
+        // build is evidence-first. The only additions are reads for logging and the per-poll
+        // record + push. The branch order and side effects match the original exactly.
         val hour = java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)
-        if (!ActiveWindow.contains(hour, settings.activeHoursStart, settings.activeHoursEnd)) {
-            return // outside active hours — skip delivery; escalation state is left frozen (not advanced, not reset)
-        }
-
+        val inWindow = ActiveWindow.contains(hour, settings.activeHoursStart, settings.activeHoursEnd)
         val minutesIdle = healthTracker.getMinutesSinceLastMovement()
+        val snap = healthTracker.debugSnapshot()
+        val total = healthTracker.totalStepsToday.value
+        val hasMove = healthTracker.hasSignificantMovement()
+        val prefix = "POLL hour=$hour inWindow=$inWindow idleMin=$minutesIdle " +
+            "winSteps=${snap.stepsInCurrentWindow} total=$total move=$hasMove"
 
-        if (healthTracker.hasSignificantMovement()) {
-            escalationManager.onMovementDetected()
-            return
+        val outcome = when {
+            // outside active hours — skip delivery; escalation state is left frozen (not advanced, not reset)
+            !inWindow -> "SKIP(outside-active-hours)"
+            hasMove -> {
+                escalationManager.onMovementDetected()
+                "SKIP(movement-reset)"
+            }
+            !escalationManager.shouldTrigger(minutesIdle) ->
+                "SKIP(no-trigger thr=${settings.inactivityThreshold})"
+            else -> fireInsult(minutesIdle, hour)
         }
 
-        if (!escalationManager.shouldTrigger(minutesIdle)) return
+        diagnostics.log("$prefix -> $outcome")
+        diagnosticsSender.syncToPhone()
+    }
 
+    /** Runs the original fire path and returns a one-line diagnostics outcome. */
+    private suspend fun fireInsult(minutesIdle: Int, hour: Int): String {
         escalationManager.onInactivityDetected(minutesIdle)
         val level = escalationManager.currentLevel.value
         val tone = ToneResolver.resolve(
@@ -129,21 +165,21 @@ class MeatsackWearService : Service() {
             workSafeEnd = settings.contextAwareEnd,
         )
 
-        val message = messageRepo.selectMessage(level, TriggerType.INACTIVITY, tone) ?: return
+        val message = messageRepo.selectMessage(level, TriggerType.INACTIVITY, tone)
+            ?: return "SKIP(no-message level=${level.value})"
 
         val steps = healthTracker.totalStepsToday.value
         val ampm = if (hour < 12) "am" else "pm"
-        val displayHour = if (hour == 0) {
-            12
-        } else if (hour > 12) {
-            hour - 12
-        } else {
-            hour
+        val displayHour = when {
+            hour == 0 -> 12
+            hour > 12 -> hour - 12
+            else -> hour
         }
         val statsText = "$steps steps. It's $displayHour$ampm. Pathetic."
 
         Log.d(TAG, "Firing insult: Level ${level.value}, idle ${minutesIdle}min")
         notificationService.deliverInsult(message, statsText)
+        return "FIRE level=${level.value}"
     }
 
     private fun createForegroundNotification(): Notification {

--- a/wear/src/main/java/com/meatsack/motivator/diagnostics/WatchDiagnostics.kt
+++ b/wear/src/main/java/com/meatsack/motivator/diagnostics/WatchDiagnostics.kt
@@ -14,7 +14,7 @@ import java.util.Locale
  * trying to catch (hypothesis H2). The full record lives here; [WatchDiagnosticsSender]
  * pushes a recent window to the phone each poll.
  *
- * Temporary — delete with the rest of the diagnostics pipe once the bug is fixed.
+ * Retained on-device dev/diagnostics tool (see docs/debug/triggering-investigation.md).
  */
 class WatchDiagnostics(private val store: DiagnosticsLineStore) {
 

--- a/wear/src/main/java/com/meatsack/motivator/diagnostics/WatchDiagnostics.kt
+++ b/wear/src/main/java/com/meatsack/motivator/diagnostics/WatchDiagnostics.kt
@@ -1,0 +1,39 @@
+package com.meatsack.motivator.diagnostics
+
+import android.content.Context
+import com.meatsack.shared.diagnostics.DiagnosticsLineStore
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Watch-side diagnostics recorder for the triggering investigation
+ * (docs/debug/triggering-investigation.md). Stamps each event with wall-clock time and
+ * appends it to a persistent on-disk buffer that survives the service/process kills we're
+ * trying to catch (hypothesis H2). The full record lives here; [WatchDiagnosticsSender]
+ * pushes a recent window to the phone each poll.
+ *
+ * Temporary — delete with the rest of the diagnostics pipe once the bug is fixed.
+ */
+class WatchDiagnostics(private val store: DiagnosticsLineStore) {
+
+    // MM-dd so a multi-day record (e.g. overnight → morning) stays unambiguous.
+    private val format = SimpleDateFormat("MM-dd HH:mm:ss", Locale.US)
+
+    /** Record one event. Newlines are stripped and the text capped so a line stays one wire row. */
+    fun log(text: String) {
+        store.append("${format.format(Date())} ${text.replace('\n', ' ').take(180)}")
+    }
+
+    fun recent(): List<String> = store.read()
+
+    fun clear() = store.clear()
+
+    companion object {
+        const val FILE_NAME = "watch_diagnostics.log"
+
+        fun create(context: Context): WatchDiagnostics =
+            WatchDiagnostics(DiagnosticsLineStore(File(context.filesDir, FILE_NAME)))
+    }
+}

--- a/wear/src/main/java/com/meatsack/motivator/health/HealthTracker.kt
+++ b/wear/src/main/java/com/meatsack/motivator/health/HealthTracker.kt
@@ -15,6 +15,9 @@ class HealthTracker(
     private val context: Context,
     stepThresholdProvider: () -> Int,
     windowMinutesProvider: () -> Int,
+    // Temporary triggering diagnostics (docs/debug/triggering-investigation.md); null in
+    // any caller that doesn't want step-level logging.
+    private val diagnostics: com.meatsack.motivator.diagnostics.WatchDiagnostics? = null,
 ) {
     private val client = HealthServices.getClient(context).passiveMonitoringClient
 
@@ -60,6 +63,13 @@ class HealthTracker(
                     val count = it.value.toInt()
                     _totalStepsToday.value = count
                     detector.onStepTotal(count)
+                    diagnostics?.let { d ->
+                        val s = detector.debugSnapshot()
+                        d.log(
+                            "STEP total=$count winSteps=${s.stepsInCurrentWindow} " +
+                                "winAgeMin=${s.windowAgeMs / 60_000L} idleMin=${s.minutesSinceLastMovement}",
+                        )
+                    }
                     // Hand-off for WorkManager workers (BehindPaceWorker, EndOfDayWorker)
                     // that don't have direct access to HealthServices. The timestamp
                     // is what lets workers reject stale or never-written values
@@ -129,4 +139,7 @@ class HealthTracker(
     fun getMinutesSinceLastMovement(): Int = detector.minutesSinceLastMovement()
 
     fun hasSignificantMovement(): Boolean = detector.hasSignificantMovement()
+
+    /** Diagnostics view of the underlying detector state (temporary). */
+    fun debugSnapshot(): MovementSnapshot = detector.debugSnapshot()
 }

--- a/wear/src/main/java/com/meatsack/motivator/health/MovementDetector.kt
+++ b/wear/src/main/java/com/meatsack/motivator/health/MovementDetector.kt
@@ -63,4 +63,28 @@ class MovementDetector(
     @Synchronized
     fun hasSignificantMovement(): Boolean =
         stepsInCurrentWindow >= stepThresholdProvider()
+
+    /**
+     * Read-only view of the detector's otherwise-private state, for the temporary
+     * triggering diagnostics (docs/debug/triggering-investigation.md). Computed under the
+     * same lock as the rest of the class so the snapshot is internally consistent.
+     */
+    @Synchronized
+    fun debugSnapshot(): MovementSnapshot {
+        val nowMs = now()
+        return MovementSnapshot(
+            minutesSinceLastMovement = ((nowMs - lastMovementTimestamp) / 60_000L).toInt(),
+            stepsInCurrentWindow = stepsInCurrentWindow,
+            windowAgeMs = nowMs - windowStartTimestamp,
+            lastStepTotal = lastStepTotal,
+        )
+    }
 }
+
+/** Snapshot of [MovementDetector] internals for diagnostics logging. */
+data class MovementSnapshot(
+    val minutesSinceLastMovement: Int,
+    val stepsInCurrentWindow: Int,
+    val windowAgeMs: Long,
+    val lastStepTotal: Int,
+)

--- a/wear/src/main/java/com/meatsack/motivator/sync/WatchDiagnosticsSender.kt
+++ b/wear/src/main/java/com/meatsack/motivator/sync/WatchDiagnosticsSender.kt
@@ -18,12 +18,12 @@ sealed class DiagnosticsSyncResult {
 }
 
 /**
- * Pushes a recent window of the watch's diagnostic log to the phone over the temporary
+ * Pushes a recent window of the watch's diagnostic log to the phone over the
  * `/diagnostics` Data Layer channel. Modelled on [WatchVoteSender]. A fresh timestamp on
  * every send guarantees the DataItem changes (so onDataChanged fires) even if the tail
  * lines happen to repeat.
  *
- * Temporary — delete with the rest of the diagnostics pipe.
+ * Retained on-device dev/diagnostics tool (see docs/debug/triggering-investigation.md).
  */
 class WatchDiagnosticsSender(
     private val context: Context,

--- a/wear/src/main/java/com/meatsack/motivator/sync/WatchDiagnosticsSender.kt
+++ b/wear/src/main/java/com/meatsack/motivator/sync/WatchDiagnosticsSender.kt
@@ -1,0 +1,56 @@
+package com.meatsack.motivator.sync
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import com.meatsack.motivator.diagnostics.WatchDiagnostics
+import com.meatsack.shared.sync.DiagnosticsSerializer
+import com.meatsack.shared.sync.SyncChannel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.tasks.await
+
+/** Outcome of a diagnostics push. Mirrors [WatchVoteSender.VoteSyncResult]'s shape. */
+sealed class DiagnosticsSyncResult {
+    data class Success(val count: Int) : DiagnosticsSyncResult()
+    data object NoData : DiagnosticsSyncResult()
+    data class Failed(val error: Throwable) : DiagnosticsSyncResult()
+}
+
+/**
+ * Pushes a recent window of the watch's diagnostic log to the phone over the temporary
+ * `/diagnostics` Data Layer channel. Modelled on [WatchVoteSender]. A fresh timestamp on
+ * every send guarantees the DataItem changes (so onDataChanged fires) even if the tail
+ * lines happen to repeat.
+ *
+ * Temporary — delete with the rest of the diagnostics pipe.
+ */
+class WatchDiagnosticsSender(
+    private val context: Context,
+    private val diagnostics: WatchDiagnostics,
+) {
+
+    companion object {
+        private const val TAG = "WatchDiagnosticsSender"
+    }
+
+    suspend fun syncToPhone(): DiagnosticsSyncResult = try {
+        val lines = diagnostics.recent().takeLast(SyncChannel.MAX_DIAG_ROWS)
+        if (lines.isEmpty()) {
+            DiagnosticsSyncResult.NoData
+        } else {
+            val request = PutDataMapRequest.create(SyncChannel.PATH_DIAGNOSTICS).apply {
+                dataMap.putString(SyncChannel.KEY_DIAG_DATA, DiagnosticsSerializer.serialize(lines))
+                dataMap.putLong(SyncChannel.KEY_TIMESTAMP, System.currentTimeMillis())
+            }.asPutDataRequest().setUrgent()
+
+            Wearable.getDataClient(context).putDataItem(request).await()
+            DiagnosticsSyncResult.Success(lines.size)
+        }
+    } catch (ce: CancellationException) {
+        throw ce
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to sync diagnostics", e)
+        DiagnosticsSyncResult.Failed(e)
+    }
+}


### PR DESCRIPTION
Adds a watch→phone **on-device diagnostics logging pipe** plus a phone **Debug screen**, kept as a standing dev-debugging aid for future feature work (not temporary scaffolding).

## What it does
- **Watch** persistently logs (to `filesDir`, survives service/process kills) every 60s poll (hour, in-window, idle minutes, step window, decision), plus lifecycle and step events, and pushes a bounded recent window to the phone each poll over a new `/diagnostics` Data Layer channel.
- **Phone** overlap-merges each pushed window into a local log and shows it newest-first (monospace, Refresh/Clear/Share) on a Debug screen reached from a button at the bottom of Settings.

## Components
- **shared:** `DiagnosticsSerializer` (wire format), `DiagnosticsLineStore` (pure-JVM capped ring buffer + overlap-merge), `SyncChannel` `/diagnostics` constants. Unit-tested.
- **wear:** `WatchDiagnostics`, `WatchDiagnosticsSender`, per-poll/lifecycle/step logging in `MeatsackWearService`, `MovementDetector.debugSnapshot()`.
- **mobile:** `PhoneDiagnosticsReceiver` (+ manifest), `DebugScreen`/`DebugViewModel`, Settings entry point.

## Notes
- Read the log via the phone Debug screen, or `run-as com.meatsack.motivator cat files/{watch,phone}_diagnostics.md`.
- Wire payload bounded well under the ~100 KB DataItem limit; sync fires each poll.
- This pipe is what pinned the root cause of the triggering bug (fixed in the stacked follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)