### PR TITLE
fix(wear): cancel prior poll loop on restart (no duplicate fires)

### DIFF
--- a/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
@@ -89,6 +89,11 @@ class MeatsackWearService : Service() {
     }
 
     private fun startPolling() {
+        // Idempotent restart: cancel any existing loop first. onStartCommand runs on every
+        // launcher-icon tap (the OS routes it to the already-alive service, no fresh onCreate),
+        // so without this each reopen would spawn an additional concurrent poll loop — all
+        // sharing one EscalationManager/HealthTracker — and fire duplicate insults per interval.
+        pollingJob?.cancel()
         pollingJob = scope.launch {
             while (true) {
                 delay(POLL_INTERVAL_MS)


### PR DESCRIPTION
Small, independent fix for a pre-existing latent bug surfaced during the [#54](https://github.com/xhf2/meatsackMotivator/pull/54) review.

## Bug
`onStartCommand` runs on **every** launcher-icon tap — the OS routes it to the already-alive service instance (no fresh `onCreate`). `startPolling()` did `pollingJob = scope.launch { while(true) … }` **without cancelling the previous job** (cancel only happened in `onDestroy`). So each reopen spawned an *additional* concurrent poll loop, all sharing one `EscalationManager`/`HealthTracker`, producing **duplicate insults** (and, on top of #54, duplicate re-entry rebaselines) per interval.

## Fix
One line: `pollingJob?.cancel()` at the top of `startPolling()`, making restart idempotent (single loop). Cancelling a coroutine `Job` is safe if it's already complete/null.

## Testing
Not unit-tested: the `Service` lifecycle has no test infra in this project (same class of change as the existing `onDestroy` cancel). Verifiable on-device via the diagnostics log — duplicate near-simultaneous `POLL` lines each interval would disappear. `wear` compiles and the existing unit suite passes.

## Scope
Branches off `main`, independent of #53/#54 (touches only `startPolling`, a distinct region). Mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)