### PR TITLE
fix(wear): stop 7am level-4 nuke and all-day insult silence

### DIFF
--- a/docs/debug/triggering-investigation.md
+++ b/docs/debug/triggering-investigation.md
@@ -101,6 +101,58 @@ Service is `START_STICKY`. **Any service/process recreate resets all idle + esca
 
 ---
 
+## FINDINGS (2026-07-02, one night + one day of on-device evidence) — ROOT CAUSE CONFIRMED
+
+The 498-line log settles it. **Both reported symptoms are a single coupled bug; H2(a) "service
+kills/restarts" is refuted.**
+
+**Service was stable:** exactly one `LIFECYCLE onCreate`/`onStartCommand` (2026-07-01 22:04),
+**no restarts** across ~18 h. So the all-day silence is NOT process death. Good thing we gathered
+evidence instead of "fixing" battery optimization.
+
+**Root cause A — H1 confirmed (overnight idle inflation → 7am level-4 nuke):**
+`minutesIdle` is pure wall-clock (`now − lastMovementTimestamp`) and the active-hours gate only
+skips *delivery* (early `return`), never the *measurement*. `lastMovementTimestamp` doesn't advance
+overnight, so idle climbed monotonically all night (02:06 → 241, 03:20 → 315) and the first
+in-window poll fired instantly at max:
+```
+07-02 07:02:50 POLL hour=7 inWindow=true idleMin=537 ... -> FIRE level=4   # (537-10)/30 = 17 escalations → EXISTENTIAL
+07-02 07:32 / 08:03 / 08:33 / 09:03  → FIRE level=4 (every ~30 min, idleMin 567→658)
+```
+
+**Root cause B — the *real* "no insults all day" (stale `lastFiredAtIdle`, movement never resets
+escalation state):**
+- `EscalationManager.onMovementDetected()` was called **0 times all day** (grep `movement-reset` = 0)
+  despite thousands of steps. Reason: `MovementDetector.onStepTotal` resets `stepsInCurrentWindow`
+  to 0 the instant it crosses the threshold, so by the next ~poll `hasSignificantMovement()` is
+  almost always false → the service never tells the EscalationManager the user moved.
+- So after the 09:03 fire pinned `lastFiredAtIdle = 658`, `shouldTrigger` gates every later poll on
+  `idleMin − 658 ≥ 30` (i.e. needs `idleMin ≥ 688`). The idle *clock* kept resetting on real walks
+  (09:35 idleMin=8, 13:39 idleMin=0) but `lastFiredAtIdle` stayed 658, so from 09:03 to 16:20 the
+  app went **silent** — every poll `SKIP(no-trigger)`, even at idleMin=204:
+```
+07-02 09:03 FIRE level=4 idleMin=658          # pins lastFiredAtIdle=658
+07-02 09:51 idleMin=24  -> SKIP(no-trigger)   # new idle streak, but 24-658 < 30
+07-02 12:51 idleMin=204 -> SKIP(no-trigger)   # still < 688
+07-02 16:19 idleMin=160 -> SKIP(no-trigger)   # silent all day
+```
+The two symptoms are the same failure: overnight inflation both fires the 7am nuke **and** corrupts
+`lastFiredAtIdle`, which then suppresses the whole day.
+
+**Contributing factor (not root cause):** background `delay()` is throttled by Doze — poll gaps ran
+13–36 min, not 60 s (e.g. 12:51 → 13:27). Coarsens resolution; note when designing the fix.
+
+**Fix direction (Phase 4 — not yet implemented; evidence-first respected):**
+1. **Rebaseline on active-window re-entry:** on the first in-window poll after being out of window,
+   reset the idle clock + escalation (`onMovementDetected()` / clamp) so the morning ramp starts
+   fresh at AGGRESSIVE instead of EXISTENTIAL. Kills the 7am nuke.
+2. **Reliably reset escalation on movement:** decouple "user moved" from the tumbling-window
+   auto-reset so `lastFiredAtIdle`/`isActive` actually clear when the user walks — OR make
+   `shouldTrigger` robust to a shrinking `idleMin` (treat `idleMin < lastFiredAtIdle` as a new
+   streak). Kills the all-day silence.
+Write a failing unit test in `EscalationManagerTest` / `MovementDetectorTest` reproducing each
+before fixing.
+
 ## Hypotheses
 
 ### H1 — "Level 4 at 7am" — HIGH confidence (from code alone)

--- a/docs/debug/triggering-investigation.md
+++ b/docs/debug/triggering-investigation.md
@@ -1,15 +1,27 @@
 # Triggering / escalation bug — investigation + debug-page plan
 
-**Status:** Phase 1 (root-cause investigation) done from code reading. **Debug instrumentation
-built** (2026-07-01, branch `fix/triggering-diagnostics`) — option A (full phone Debug screen),
-evidence-first (no behavior fix yet). Builds + unit tests green; **awaiting install on the
-physical devices, then a day of on-device evidence before fixing.**
+**Status: RESOLVED & VERIFIED ON-DEVICE (2026-07-03).** Both bugs fixed on
+`fix/triggering-escalation`; confirmed on the physical watch (see "Verification" below). The
+diagnostics pipe that found the bug is **retained as a standing on-device dev tool** (per the
+user), not stripped — see [[project_ondevice_diagnostics_pipe]].
+
+## Verification (2026-07-03, physical SM-L320)
+- **Root cause A fixed:** at the 07:00 active-window boundary the log shows
+  `REBASELINE active-window re-entry hour=7`, then `07:11 idleMin=10 -> FIRE level=1` (was
+  `07:02 idleMin=537 -> FIRE level=4` the day before). Fresh morning ramp 1 → 2, no nuke.
+- **Root cause B fixed:** daytime fires resume after idle stretches instead of the all-day
+  `SKIP(no-trigger)` silence.
+- **Charger note (benign):** putting the watch on the charger (off-wrist) at ~07:42 let the OS
+  hard-kill the service (`onCreate` at 13:33 with no `onDestroy`, ~5.5 h gap). Expected Wear/Samsung
+  battery behavior — and self-correcting: the restart reconstructs fresh state and the first
+  in-window poll `REBASELINE`s, so no post-charge nuke. This is the original H2(a) ("service
+  killed"), seen only while charging/off-wrist, never during normal wear.
 
 ---
 
 ## What was built (the diagnostics pipe)
 
-Temporary, clearly marked "remove with the rest of the diagnostics pipe". Mirrors the existing
+Now a **retained on-device dev tool** (originally built to find this bug). Mirrors the existing
 `/votes` back-sync pipe.
 
 - **shared**

--- a/docs/debug/triggering-investigation.md
+++ b/docs/debug/triggering-investigation.md
@@ -142,7 +142,16 @@ The two symptoms are the same failure: overnight inflation both fires the 7am nu
 **Contributing factor (not root cause):** background `delay()` is throttled by Doze — poll gaps ran
 13–36 min, not 60 s (e.g. 12:51 → 13:27). Coarsens resolution; note when designing the fix.
 
-**Fix direction (Phase 4 — not yet implemented; evidence-first respected):**
+**STATUS 2026-07-02 17:52:** Fix IMPLEMENTED + committed (`fix/triggering-escalation`, db4517a,
+TDD, all unit tests green) and INSTALLED on the watch. Root-cause-A wiring verified live — the
+first in-window poll after install logged `REBASELINE active-window re-entry` and reset `idleMin`
+to 0 instead of inheriting the old build's 250. Diagnostics pipe left in place. **Pending: the 7am
+boundary + a normal day tomorrow (2026-07-03) to confirm no level-4 nuke and no all-day silence,
+then strip diagnostics + open PR.** What to check tomorrow: a `REBASELINE ... hour=7` line at the
+first in-window poll; the 7am poll showing small `idleMin` → NOT `FIRE level=4`; and daytime
+`FIRE`s resuming after idle stretches (no endless `SKIP(no-trigger)`).
+
+**Fix direction (Phase 4 — IMPLEMENTED as above; kept for reference):**
 1. **Rebaseline on active-window re-entry:** on the first in-window poll after being out of window,
    reset the idle clock + escalation (`onMovementDetected()` / clamp) so the morning ramp starts
    fresh at AGGRESSIVE instead of EXISTENTIAL. Kills the 7am nuke.

--- a/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.meatsack.motivator.diagnostics.WatchDiagnostics
 import com.meatsack.motivator.escalation.EscalationManager
+import com.meatsack.motivator.escalation.WindowReentryDetector
 import com.meatsack.motivator.health.HealthTracker
 import com.meatsack.motivator.messages.ActiveWindow
 import com.meatsack.motivator.messages.MessageRepository
@@ -44,6 +45,9 @@ class MeatsackWearService : Service() {
 
     private var pollingJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    // Root cause A: detects crossing back into the active window so the day's ramp starts fresh.
+    private val reentryDetector = WindowReentryDetector()
 
     companion object {
         private const val TAG = "MeatsackWearService"
@@ -132,6 +136,16 @@ class MeatsackWearService : Service() {
         // record + push. The branch order and side effects match the original exactly.
         val hour = java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)
         val inWindow = ActiveWindow.contains(hour, settings.activeHoursStart, settings.activeHoursEnd)
+
+        // Root cause A: on crossing back into the active window, rebaseline the idle clock and
+        // escalation so the morning ramp starts fresh at AGGRESSIVE instead of inheriting the
+        // overnight idle accumulation (which fired straight to level 4 at 7am).
+        if (reentryDetector.onPoll(inWindow)) {
+            healthTracker.rebaselineIdle()
+            escalationManager.onMovementDetected()
+            diagnostics.log("REBASELINE active-window re-entry hour=$hour")
+        }
+
         val minutesIdle = healthTracker.getMinutesSinceLastMovement()
         val snap = healthTracker.debugSnapshot()
         val total = healthTracker.totalStepsToday.value

--- a/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
+++ b/wear/src/main/java/com/meatsack/motivator/MeatsackWearService.kt
@@ -39,7 +39,7 @@ class MeatsackWearService : Service() {
     private lateinit var notificationService: InsultNotificationService
     private lateinit var settings: WatchSettingsCache
 
-    // Temporary triggering diagnostics (docs/debug/triggering-investigation.md).
+    // On-device diagnostics — retained dev tool (docs/debug/triggering-investigation.md).
     private lateinit var diagnostics: WatchDiagnostics
     private lateinit var diagnosticsSender: WatchDiagnosticsSender
 

--- a/wear/src/main/java/com/meatsack/motivator/escalation/EscalationManager.kt
+++ b/wear/src/main/java/com/meatsack/motivator/escalation/EscalationManager.kt
@@ -61,6 +61,11 @@ class EscalationManager(
         if (minutesIdle < threshold) return false
         val interval = EscalationLevel.ESCALATION_INTERVAL_MINUTES
         val last = lastFiredAtIdle ?: return true
+        // A shrunk idle means the idle clock was reset by movement since the last fire — i.e. a
+        // fresh inactivity streak. Fire from scratch instead of comparing against the now-stale
+        // (possibly overnight-inflated) baseline, which otherwise pins the interval out of reach
+        // and silences the app all day (docs/debug/triggering-investigation.md, root cause B).
+        if (minutesIdle < last) return true
         return (minutesIdle - last) >= interval
     }
 

--- a/wear/src/main/java/com/meatsack/motivator/escalation/WindowReentryDetector.kt
+++ b/wear/src/main/java/com/meatsack/motivator/escalation/WindowReentryDetector.kt
@@ -1,0 +1,21 @@
+package com.meatsack.motivator.escalation
+
+/**
+ * Tracks active-hours window membership across polls and reports the moment the app crosses
+ * from outside the window to inside it. The service uses that edge to rebaseline the idle
+ * clock + escalation state so the morning ramp starts fresh (root cause A in
+ * docs/debug/triggering-investigation.md).
+ *
+ * The first in-window poll counts as a re-entry (starting state is "outside"), which is
+ * harmless — a fresh start rebaselines an already-fresh baseline.
+ */
+class WindowReentryDetector {
+    private var wasInside = false
+
+    /** Returns true exactly on an outside → inside transition. */
+    fun onPoll(inWindow: Boolean): Boolean {
+        val reentered = inWindow && !wasInside
+        wasInside = inWindow
+        return reentered
+    }
+}

--- a/wear/src/main/java/com/meatsack/motivator/health/HealthTracker.kt
+++ b/wear/src/main/java/com/meatsack/motivator/health/HealthTracker.kt
@@ -140,6 +140,9 @@ class HealthTracker(
 
     fun hasSignificantMovement(): Boolean = detector.hasSignificantMovement()
 
+    /** Reset the idle baseline + current step window to now (used on active-window re-entry). */
+    fun rebaselineIdle() = detector.rebaseline()
+
     /** Diagnostics view of the underlying detector state (temporary). */
     fun debugSnapshot(): MovementSnapshot = detector.debugSnapshot()
 }

--- a/wear/src/main/java/com/meatsack/motivator/health/HealthTracker.kt
+++ b/wear/src/main/java/com/meatsack/motivator/health/HealthTracker.kt
@@ -15,7 +15,7 @@ class HealthTracker(
     private val context: Context,
     stepThresholdProvider: () -> Int,
     windowMinutesProvider: () -> Int,
-    // Temporary triggering diagnostics (docs/debug/triggering-investigation.md); null in
+    // On-device diagnostics — retained dev tool (docs/debug/triggering-investigation.md); null in
     // any caller that doesn't want step-level logging.
     private val diagnostics: com.meatsack.motivator.diagnostics.WatchDiagnostics? = null,
 ) {
@@ -143,6 +143,6 @@ class HealthTracker(
     /** Reset the idle baseline + current step window to now (used on active-window re-entry). */
     fun rebaselineIdle() = detector.rebaseline()
 
-    /** Diagnostics view of the underlying detector state (temporary). */
+    /** Diagnostics view of the underlying detector state. */
     fun debugSnapshot(): MovementSnapshot = detector.debugSnapshot()
 }

--- a/wear/src/main/java/com/meatsack/motivator/health/MovementDetector.kt
+++ b/wear/src/main/java/com/meatsack/motivator/health/MovementDetector.kt
@@ -79,8 +79,8 @@ class MovementDetector(
     }
 
     /**
-     * Read-only view of the detector's otherwise-private state, for the temporary
-     * triggering diagnostics (docs/debug/triggering-investigation.md). Computed under the
+     * Read-only view of the detector's otherwise-private state, for the on-device
+     * diagnostics dev tool (docs/debug/triggering-investigation.md). Computed under the
      * same lock as the rest of the class so the snapshot is internally consistent.
      */
     @Synchronized

--- a/wear/src/main/java/com/meatsack/motivator/health/MovementDetector.kt
+++ b/wear/src/main/java/com/meatsack/motivator/health/MovementDetector.kt
@@ -65,6 +65,20 @@ class MovementDetector(
         stepsInCurrentWindow >= stepThresholdProvider()
 
     /**
+     * Reset the idle clock and the current step window to "now", leaving the cumulative
+     * [lastStepTotal] baseline intact so later deltas stay correct. Called on active-window
+     * re-entry so the day's inactivity ramp starts fresh instead of inheriting the overnight
+     * accumulation that fired level 4 at 7am (docs/debug/triggering-investigation.md, root cause A).
+     */
+    @Synchronized
+    fun rebaseline() {
+        val nowMs = now()
+        lastMovementTimestamp = nowMs
+        windowStartTimestamp = nowMs
+        stepsInCurrentWindow = 0
+    }
+
+    /**
      * Read-only view of the detector's otherwise-private state, for the temporary
      * triggering diagnostics (docs/debug/triggering-investigation.md). Computed under the
      * same lock as the rest of the class so the snapshot is internally consistent.

--- a/wear/src/test/java/com/meatsack/motivator/escalation/EscalationManagerTest.kt
+++ b/wear/src/test/java/com/meatsack/motivator/escalation/EscalationManagerTest.kt
@@ -99,6 +99,21 @@ class EscalationManagerTest {
     }
 
     @Test
+    fun `re-fires when the idle clock resets to a new streak after firing`() {
+        // Repro of the on-device silence (2026-07-02, docs/debug/triggering-investigation.md):
+        // an overnight-inflated fire pinned lastFiredAtIdle high (658). When the user moved,
+        // the idle clock reset to a small value, but shouldTrigger compared the fresh idle
+        // against the stale 658 and returned false for the rest of the day.
+        val em = EscalationManager(thresholdProvider = { 10 })
+        assertTrue(em.shouldTrigger(658))
+        em.onInactivityDetected(658) // fired at the inflated overnight idle
+
+        // User walks -> idle clock resets -> a fresh idle streak climbs back over threshold.
+        // A shrunk idle means movement happened, so this is a new streak and must fire.
+        assertTrue("a new idle streak after movement must fire", em.shouldTrigger(24))
+    }
+
+    @Test
     fun `snooze blocks triggers during window`() {
         manager.snooze(durationMinutes = 60)
         assertFalse(manager.shouldTrigger(30))

--- a/wear/src/test/java/com/meatsack/motivator/escalation/EscalationManagerTest.kt
+++ b/wear/src/test/java/com/meatsack/motivator/escalation/EscalationManagerTest.kt
@@ -114,6 +114,21 @@ class EscalationManagerTest {
     }
 
     @Test
+    fun `shrunk-idle re-fire re-anchors and then gates the fresh streak by the interval`() {
+        // Guards against a notification storm: the shrunk-idle branch must fire only ONCE per
+        // fresh streak. Firing re-anchors lastFiredAtIdle to the small value (via
+        // onInactivityDetected), so the next poll waits the interval again and the level drops
+        // back to AGGRESSIVE rather than inheriting the inflated one.
+        val em = EscalationManager(thresholdProvider = { 10 })
+        em.onInactivityDetected(658) // inflated overnight fire (EXISTENTIAL)
+        assertTrue(em.shouldTrigger(24))
+        em.onInactivityDetected(24) // fire the fresh streak
+        assertEquals(EscalationLevel.AGGRESSIVE, em.currentLevel.value)
+        assertFalse("must not fire again on the very next poll", em.shouldTrigger(25))
+        assertTrue("fires once the interval elapses from the re-anchored baseline", em.shouldTrigger(54))
+    }
+
+    @Test
     fun `snooze blocks triggers during window`() {
         manager.snooze(durationMinutes = 60)
         assertFalse(manager.shouldTrigger(30))

--- a/wear/src/test/java/com/meatsack/motivator/escalation/WindowReentryDetectorTest.kt
+++ b/wear/src/test/java/com/meatsack/motivator/escalation/WindowReentryDetectorTest.kt
@@ -1,0 +1,25 @@
+package com.meatsack.motivator.escalation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WindowReentryDetectorTest {
+
+    @Test
+    fun `signals re-entry only on an outside-to-inside transition`() {
+        val d = WindowReentryDetector()
+        // First in-window poll counts as a re-entry (fresh baseline on start / after being out).
+        assertTrue("first inside poll is a re-entry", d.onPoll(inWindow = true))
+        assertFalse("staying inside is not a re-entry", d.onPoll(inWindow = true))
+        assertFalse("leaving the window is not a re-entry", d.onPoll(inWindow = false))
+        assertFalse("staying outside is not a re-entry", d.onPoll(inWindow = false))
+        assertTrue("coming back inside is a re-entry", d.onPoll(inWindow = true))
+    }
+
+    @Test
+    fun `does not signal re-entry when starting outside the window`() {
+        val d = WindowReentryDetector()
+        assertFalse(d.onPoll(inWindow = false))
+    }
+}

--- a/wear/src/test/java/com/meatsack/motivator/health/MovementDetectorTest.kt
+++ b/wear/src/test/java/com/meatsack/motivator/health/MovementDetectorTest.kt
@@ -101,6 +101,35 @@ class MovementDetectorTest {
     }
 
     @Test
+    fun rebaseline_resetsIdleClockToNow() {
+        // Used on active-window re-entry so the morning ramp starts fresh instead of
+        // inheriting the overnight idle accumulation that fired level 4 at 7am
+        // (docs/debug/triggering-investigation.md, root cause A).
+        clock = 0
+        val d = newDetector()
+        d.onStepTotal(5000) // baseline
+        clock = 540 * 60_000L // 9 hours later with no movement
+        assertEquals(540, d.minutesSinceLastMovement())
+        d.rebaseline()
+        assertEquals(0, d.minutesSinceLastMovement())
+    }
+
+    @Test
+    fun rebaseline_clearsPartialWindowSteps() {
+        clock = 0
+        val d = newDetector()
+        d.onStepTotal(1000) // baseline
+        clock = 60_000L
+        d.onStepTotal(1040) // +40 banked in the window, below the 50 threshold
+        d.rebaseline() // rebaseline at t=1min: idle clock -> now, partial window -> 0
+        // A stale partial window must not survive and later tip a false movement crossing.
+        clock = 120_000L
+        d.onStepTotal(1055) // +15 => 15 in the fresh window; if the stale 40 survived, 40+15=55 >= 50 would cross
+        // No crossing => idle clock still anchored at the rebaseline (1 min ago), not reset to 0.
+        assertEquals(1, d.minutesSinceLastMovement())
+    }
+
+    @Test
     fun stepThresholdProviderIsReadLive() {
         clock = 0
         stepThreshold = 100


### PR DESCRIPTION
Fixes two coupled triggering bugs, confirmed from a full day of on-device evidence (the strongest prior hypothesis — the OS killing the service — was **refuted**: the service ran ~18h with zero restarts during normal wear).

> Reopened from #54, which GitHub auto-closed when its stacked base branch (`fix/triggering-diagnostics`, now merged via #53) was deleted. Review discussion and the two-agent review pass are on #54.

## Root cause A — 7am level-4 nuke
`minutesIdle` is wall-clock and the active-hours gate only skips *delivery*, not *measurement*, so idle climbed all night (`idleMin=537` by 07:02) and the first in-window poll fired straight to EXISTENTIAL. **Fix:** on active-window re-entry, rebaseline the idle clock (`MovementDetector.rebaseline()` via a new `WindowReentryDetector`) and reset escalation, so the morning ramp starts fresh at AGGRESSIVE.

## Root cause B — silent all day
After an inflated fire pinned `lastFiredAtIdle` high (658), `shouldTrigger` compared each fresh idle against it and never fired again (needed `idleMin ≥ 688`). Movement reset the idle clock but not the escalation state. **Fix:** `shouldTrigger` now treats a shrunk `idleMin` as a new streak and fires — self-healing without depending on the poll-timing race.

## Tests (TDD — failing first)
`EscalationManagerTest` (new-streak re-fire + re-anchor/interval-gating regression guard), `MovementDetectorTest` (rebaseline resets idle + clears window), new `WindowReentryDetectorTest`.

## On-device verification (2026-07-03, SM-L320)
```
07:00  REBASELINE active-window re-entry hour=7
07:11  idleMin=10 -> FIRE level=1     (was 07:02 idleMin=537 -> FIRE level=4)
07:42  idleMin=41 -> FIRE level=2
```
Ramp resumes normally; no nuke, no all-day silence. Full analysis in `docs/debug/triggering-investigation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)